### PR TITLE
fix bug introduced in previous commit

### DIFF
--- a/src/qumin/utils/__init__.py
+++ b/src/qumin/utils/__init__.py
@@ -160,7 +160,7 @@ class ArgumentDefaultsRawTextHelpFormatter(argparse.RawDescriptionHelpFormatter)
         return help
 
 
-def get_default_parser(usage, patterns=False, paradigms=True, multipar=True):
+def get_default_parser(usage, patterns=False, paradigms=True, multipar=False):
 
     parser = argparse.ArgumentParser(description=usage,
                                      formatter_class=ArgumentDefaultsRawTextHelpFormatter)


### PR DESCRIPTION
I introduced a bug by setting the wrong value to a new optional argument for the default argparse. This argument is used by the eval script, which takes multiple input paradigms (vs. eg find_patterns, which takes only one paradigm arg)

The commit fixes this issue by setting the default to False