### PR TITLE
Fix bug introduced with the --cells argument.

### DIFF
--- a/src/qumin/calc_paradigm_entropy.py
+++ b/src/qumin/calc_paradigm_entropy.py
@@ -42,7 +42,7 @@ def main(args):
         preds.pop(0)
 
     cells = args.cells
-    if len(cells) == 1:
+    if cells and len(cells) == 1:
         raise argparse.ArgumentTypeError("You can't provide only one cell.")
 
     # Define logging levels (different depending on verbosity)

--- a/src/qumin/find_patterns.py
+++ b/src/qumin/find_patterns.py
@@ -42,7 +42,7 @@ def main(args):
     features_file_name = args.segments
     data_file_path = args.paradigms
     cells = args.cells
-    if len(cells) == 1:
+    if cells and len(cells) == 1:
         raise argparse.ArgumentTypeError("You can't provide only one cell.")
 
     is_of_pattern_type = kind.startswith("patterns")


### PR DESCRIPTION
Fix bug introduced at #23 or #21.
When no `--cells` argument was provided, a bug happened because `None` is not a list (this is the reason why I previously used `[]` as default value I think).
This checks first if cells are provided.