### PR TITLE
new feature heatmaps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,9 @@ The config file contains the following keys, which can be set through the comman
                                # This forces seaborn to print all labels.
       dense: False             # Use initials instead of full labels (only for entropy heatmap)
       annotate: False          # Display values on the heatmap. (only for entropy heatmap)
-      order: False             # Priority list for sorting features (for entropy heatmap, ex: [number, case]) or an ordered list of the cells to display.
+      order: False             # Priority list for sorting features (for entropy heatmap)
+                               # ex: [number, case]). If no features-values file available,
+                               # it should contain an ordered list of the cells to display.
     entropy:
       heatmap: True        # Whether to draw a heatmap.
 

--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,29 @@ For bipartite systems, it is possible to pass two values to both patterns and da
     /$ qumin.H  patterns="[<patterns1.csv>,<patterns2.csv>]" data="[<dataset1.package.json>,<dataset2.package.json>]"
 
 
+Visualizing results
+^^^^^^^^^^^^^^^^^^^
+
+Since Qumin 2.0, results are shipped as long tables. This allows to store several metrics in the same file, with results for several runs. As a drawback, it becomes harder to get an idea of the results. For entropy computations, a script automatically reads these files and displays the results as heatmaps. This behaviour can be disable with `ent_hm.enable`. It takes advantage of the Paralex `features-values` table to sort the cells in a canonical order on the heatmap. The `ent_hm.order` setting is used to specify which feature should have higher priority in the sorting: ::
+
+    /$ qumin action=H data=<dataset.package.json> ent_hm.order="[number, case]"
+
+It is also possible to draw an entropy heatmap without running entropy computations: ::
+
+    /$ qumin action=ent_heatmap ent_hm.results=<entropies.csv>
+
+The config file contains the following keys, which can be set through the command line: ::
+
+    ent_hm:
+      results: null            # A file with entropy computation results.
+      order: False             # Priority list for sorting features (ex: [number, case]) or an ordered list of the cells to display.
+      cmap: null               # colormap name
+      exhaustive_labels: False # by default, seaborn shows only some label
+                               # the heatmap for readability.
+                               # This forces seaborn to print all labels.
+      dense: False             # Use initials instead of full labels
+      annotate: False          # Display values on the heatmap.
+
 Macroclass inference
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
 .. |DocStatus| image:: https://readthedocs.org/projects/qumin/badge/?version=dev
 .. _DocStatus: https://qumin.readthedocs.io/dev/?badge=latest
 
-Qumin (QUantitative Modelling of INflection) is a package for the computational modelling of the inflectional morphology of languages. It was initially developed for `my PhD dissertation <https://tel.archives-ouvertes.fr/tel-01840448>`_.
+Qumin (QUantitative Modelling of INflection) is a package for the computational modelling of the inflectional morphology of languages. It was initially developed for `Sacha Beniamine's PhD dissertation <https://tel.archives-ouvertes.fr/tel-01840448>`_.
 
 **Contributors**: Sacha Beniamine, Jules Bouton.
 
@@ -15,10 +15,15 @@ Qumin (QUantitative Modelling of INflection) is a package for the computational 
 **Github**: https://github.com/XachaB/Qumin
 
 
-This is version 2, which was significantly updated since the publications cited below.
+This is **version 2**, which was significantly updated since the publications cited below. These updates do not affect results, and focused on bugfixes, command line interface, paralex compatibility, workflow improvement and overall tidyness.
 
-For more detail, you can refer to Sacha's dissertation (in French, `Beniamine 2018 <https://tel.archives-ouvertes.fr/tel-01840448>`_). If you use(d) Qumin in a publication, send me an email with the reference at s.<last name>@surrey.ac.uk
+For more detail, you can refer to Sacha's dissertation (in French, `Beniamine 2018 <https://tel.archives-ouvertes.fr/tel-01840448>`_).
 
+
+Citing
+============
+
+If you use Qumin in your research, please cite Sacha's dissertation (`Beniamine 2018 <https://tel.archives-ouvertes.fr/tel-01840448>`_), as well as the relevant paper for the specific actions used (see below). To appear in the publications list, send Sacha an email with the reference of your publication at s.<last name>@surrey.ac.uk
 
 Quick Start
 ============
@@ -26,33 +31,23 @@ Quick Start
 Install
 --------
 
-First, open the terminal and navigate to the folder where you want the Qumin code. Clone the repository from github: ::
+Install the Qumin package using pip: ::
 
-    git clone https://github.com/XachaB/Qumin.git
-
-Install the Qumin package: ::
-
-    cd Qumin
-    pip install -e ./
-
-Navigate to your working directory: ::
-
-    cd ~/my/workdir/
-
+    pip install qumin
 
 Data
 -----
 
-The package expects full paradigm data in phonemic transcription, as well as a feature key for the transcription.
+Qumin works from full paradigm data in phonemic transcription.
 
-For compatible data, see the `Paralex datasets <http://www.paralex-standard.org>`_. The sounds files may sometimes require edition, as Qumin as more constraints on sound definitions.
+The package expects `Paralex datasets <http://www.paralex-standard.org>`_, containing at least a `forms` and a `sounds` table. Note that the sounds files may sometimes require edition, as Qumin imposes more constraints on sound definitions than paralex does.
 
 
 Scripts
 --------
 
 .. note::
-    We now rely on `hydra <https://hydra.cc/>`_ to manage CLI interface and configurations. Hydra will create a folder ``outputs/<yyyy-mm-dd>/<hh-mm-ss>/`` containing all results. A subfolder ``outputs/<yyyy-mm-dd>/<hh-mm-ss>/.hydra/`` contains details of the configuration as it was when the script was run. Hydra permits a lot more configuration. For example, any of the following scripts can accept a verbose argument of the form `hydra.verbose=True`.
+    We now rely on `hydra <https://hydra.cc/>`_ to manage CLI interface and configurations. Hydra will create a folder ``outputs/<yyyy-mm-dd>/<hh-mm-ss>/`` containing all results. A subfolder ``outputs/<yyyy-mm-dd>/<hh-mm-ss>/.hydra/`` contains details of the configuration as it was when the script was run. Hydra permits a lot more configuration. For example, any of the following scripts can accept a verbose argument of the form ``hydra.verbose=True``, and the output directory can be customized with ``hydra.run.dir="./path/to/output/dir"``.
 
 **More details on configuration:**::
 
@@ -61,14 +56,15 @@ Scripts
 Patterns
 ^^^^^^^^^
 
-Alternation patterns serve as a basis for all the other scripts. An early version of the algorithm to find the patterns was presented in `Beniamine (2017) <https://halshs.archives-ouvertes.fr/hal-01615899>`_. An updated description of the algorithm figures in `Beniamine, Bonami and  Luís (2021) <https://doi.org/10.5565/rev/isogloss.109>`_.
+Alternation patterns serve as a basis for all the other scripts. An early version of the patterns algorithm is described in `Beniamine (2017) <https://halshs.archives-ouvertes.fr/hal-01615899>`_. An updated description figures in `Beniamine, Bonami and  Luís (2021) <https://doi.org/10.5565/rev/isogloss.109>`_.
 
-The default action is to compute patterns only, so these two commands are identical: ::
+The default action for Qumin is to compute patterns only, so these two commands are identical: ::
 
     /$ qumin data=<dataset.package.json>
     /$ qumin action=patterns data=<dataset.package.json>
 
 By default, Qumin will ignore defective lexemes and overabundant forms.
+
 For paradigm entropy, it is possible to explicitly keep defective lexemes: ::
 
     /$ qumin pats.defective=True data=<dataset.package.json>
@@ -92,7 +88,7 @@ It is also possible to pass class labels to facilitate comparisons with another 
 
     /$ qumin.heatmap label=inflection_class patterns=<path/to/patterns.csv> data=<dataset.package.json>
 
-The labels is the name of the column in the Paralex `lexemes` table to use as labels. This allows to visually compare a manual classification with pattern-based similarity. This command relies heavily on `seaborn's clustermap <https://seaborn.pydata.org/generated/seaborn.clustermap.html>`__ function.
+The label key is the name of the column in the Paralex `lexemes` table to use as labels.
 
 A few more parameters can be changed: ::
 
@@ -106,7 +102,7 @@ A few more parameters can be changed: ::
 Paradigm entropy
 ^^^^^^^^^^^^^^^^^^
 
-An early version of this software was used in `Bonami and Beniamine 2016 <http://www.llf.cnrs.fr/fr/node/4789>`_,  `Beniamine, Bonami and Luís (2021) <https://doi.org/10.5565/rev/isogloss.109>`_
+An early version of this software was used in `Bonami and Beniamine 2016 <http://www.llf.cnrs.fr/fr/node/4789>`_, and a more recent one in `Beniamine, Bonami and Luís (2021) <https://doi.org/10.5565/rev/isogloss.109>`_
 
 By default, this will start by computing patterns. To work with pre-computed patterns, pass their path with ``patterns=<path/to/patterns.csv>``.
 
@@ -148,7 +144,19 @@ For bipartite systems, it is possible to pass two values to both patterns and da
 Visualizing results
 ^^^^^^^^^^^^^^^^^^^
 
-Since Qumin 2.0, results are shipped as long tables. This allows to store several metrics in the same file, with results for several runs. As a drawback, it becomes harder to get an idea of the results. For entropy computations, a script automatically reads these files and displays the results as heatmaps. This behaviour can be disabled by passing `entropy.heatmap=False`. It takes advantage of the Paralex `features-values` table to sort the cells in a canonical order on the heatmap. The `heatmap.order` setting is used to specify which feature should have higher priority in the sorting: ::
+Since Qumin 2.0, results are shipped as long tables. This allows to store several metrics in the same file, with results for several runs. Results file now look like this: ::
+
+    predictor,predicted,measure,value,n_pairs,n_preds,dataset
+    <cell1>,<cell2>,cond_entropy,0.39,500,1,<dataset_name>
+    <cell1>,<cell2>,cond_entropy,0.35,500,1,<dataset_name>
+    <cell1>,<cell2>,cond_entropy,0.2,500,1,<dataset_name>
+    <cell1>,<cell2>,cond_entropy,0.43,500,1,<dataset_name>
+    <cell1>,<cell2>,cond_entropy,0.6,500,1,<dataset_name>
+    <cell1>,<cell2>,cond_entropy,0.1,500,1,<dataset_name>
+
+All results are in the same file, including different number of predictors (indicated in the `n_preds` column), and different measures (indicated in the `measure` column).
+
+To facilitate a quick general glance at the results, we output an entropy heatmap in the wide matrix format. This behaviour can be disabled by passing `entropy.heatmap=False`. It takes advantage of the Paralex `features-values` table to sort the cells in a canonical order on the heatmap. The `heatmap.order` setting is used to specify which feature should have higher priority in the sorting: ::
 
     /$ qumin action=H data=<dataset.package.json> heatmap.order="[number, case]"
 

--- a/README.rst
+++ b/README.rst
@@ -148,25 +148,27 @@ For bipartite systems, it is possible to pass two values to both patterns and da
 Visualizing results
 ^^^^^^^^^^^^^^^^^^^
 
-Since Qumin 2.0, results are shipped as long tables. This allows to store several metrics in the same file, with results for several runs. As a drawback, it becomes harder to get an idea of the results. For entropy computations, a script automatically reads these files and displays the results as heatmaps. This behaviour can be disable with `ent_hm.enable`. It takes advantage of the Paralex `features-values` table to sort the cells in a canonical order on the heatmap. The `ent_hm.order` setting is used to specify which feature should have higher priority in the sorting: ::
+Since Qumin 2.0, results are shipped as long tables. This allows to store several metrics in the same file, with results for several runs. As a drawback, it becomes harder to get an idea of the results. For entropy computations, a script automatically reads these files and displays the results as heatmaps. This behaviour can be disabled by passing `entropy.heatmap=False`. It takes advantage of the Paralex `features-values` table to sort the cells in a canonical order on the heatmap. The `heatmap.order` setting is used to specify which feature should have higher priority in the sorting: ::
 
-    /$ qumin action=H data=<dataset.package.json> ent_hm.order="[number, case]"
+    /$ qumin action=H data=<dataset.package.json> heatmap.order="[number, case]"
 
 It is also possible to draw an entropy heatmap without running entropy computations: ::
 
-    /$ qumin action=ent_heatmap ent_hm.results=<entropies.csv>
+    /$ qumin action=ent_heatmap entropy.importFile=<entropies.csv>
 
 The config file contains the following keys, which can be set through the command line: ::
 
-    ent_hm:
-      results: null            # A file with entropy computation results.
-      order: False             # Priority list for sorting features (ex: [number, case]) or an ordered list of the cells to display.
+    heatmap:
       cmap: null               # colormap name
-      exhaustive_labels: False # by default, seaborn shows only some label
+      exhaustive_labels: False # by default, seaborn shows only some labels on
                                # the heatmap for readability.
                                # This forces seaborn to print all labels.
-      dense: False             # Use initials instead of full labels
-      annotate: False          # Display values on the heatmap.
+      dense: False             # Use initials instead of full labels (only for entropy heatmap)
+      annotate: False          # Display values on the heatmap. (only for entropy heatmap)
+      order: False             # Priority list for sorting features (for entropy heatmap, ex: [number, case]) or an ordered list of the cells to display.
+    entropy:
+      heatmap: True        # Whether to draw a heatmap.
+
 
 Macroclass inference
 ^^^^^^^^^^^^^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,3 +51,4 @@ universal = true
 [options.entry_points]
 console_scripts =
     qumin = qumin.cli:qumin_command
+    qumin.ent_heatmap = qumin.entropy_heatmap:heatmap_command

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,4 +51,3 @@ universal = true
 [options.entry_points]
 console_scripts =
     qumin = qumin.cli:qumin_command
-    qumin.ent_heatmap = qumin.entropy_heatmap:heatmap_command

--- a/sphinx/patterns.rst
+++ b/sphinx/patterns.rst
@@ -45,4 +45,4 @@ Qumin can compute various kinds of patterns. Only the ones prefixed by "patterns
     * ``patternsPrefix``: Fixed right alignment, only interesting for prefixal languages.
     * ``patternsBaseline``: Baseline alignment, follows Albright & Hayes 2002. A single change, with a priority order: Suffixation > Prefixation > Stem-internal alternation (ablaut/infixation)
 
-Most of these were implemented for comparison purposes. I recommend to use the default `patternsPhonsim` in most cases. To avoid relying on your phonological features files for alignment scores, use `patternsLevenshtein`. Only these two are full patterns with generalization both in the context and alternation.
+Most of these were implemented for comparison purposes during Sacha Beniamine's PhD. It is recommended to use the default `patternsPhonsim` in most cases. To avoid relying on your phonological features files for alignment scores, use `patternsLevenshtein`. Only these two are full patterns with generalization both in the context and alternation.

--- a/sphinx/publications.rst
+++ b/sphinx/publications.rst
@@ -4,8 +4,8 @@ Qumin bibliography
 
 Here are publications which made use of Qumin. If you use Qumin in a publication, send me an email at with the reference at s.<last name>@surrey.ac.uk in order to be cited here !
 
-- Herce, Borja & Bogdan Pricop. Accepted. VeLeRo: An inflected verbal lexicon of Standard Romanian and a quantitative analysis of morphological predictability. Language Resources and Evaluation.
-- Herce, Borja. Submitted. VeLePa: Central Pame verbal inflection in a quantitative perspective.
+- Herce, Borja & Bogdan Pricop. 2024. VeLeRo: An inflected verbal lexicon of Standard Romanian and a quantitative analysis of morphological predictability. Language Resources and Evaluation.
+- Herce, Borja. 2024. VeLePa: Central Pame verbal inflection in a quantitative perspective.
 - Pellegrini, Matteo (2023). Paradigm Structure and Predictability in Latin Inflection: An Entropy-based Approach, vol. 6. in Studies in Morphology, vol. 6. Springer, 2023. doi: `10.1007/978-3-031-24844-3 <https://doi.org/10.1007/978-3-031-24844-3>`_
 - Pellegrini, Matteo (2023). “Flexemes in theory and in practice: Modelling overabundance in Latin verb paradigms,” Morphology, vol. 33, no. 3, pp. 361–395, 2023, doi: `10.1007/s11525-023-09414-7 <https://doi.org/10.1007/s11525-023-09414-7>`_.
 - Beniamine, Sacha. (2021) "`One lexeme, many classes: inflection class systems as lattices <https://langsci-press.org/catalog/book/262>`_" , In: One-to-Many Relations in Morphology, Syntax and Semantics , Ed. by Berthold Crysmann and Manfred Sailer. Berlin: Language Science Press.

--- a/sphinx/segments.rst
+++ b/sphinx/segments.rst
@@ -1,7 +1,7 @@
 The phonological segments file
 ================================
 
-Qumin works from the assumption that your paradigms are written in phonemic notation. The phonological segments file provides a list of phonemes and their decomposition into distinctive features. This file is first used to segment the paradigms into sequences of phonemes (rather than sequences of characters). Then, the distinctive features are used to recognize phonological similarity and natural classes when creating and handling alternation patterns.
+Qumin works from the assumption that your paradigms are written in phonemic notation. The phonological segments file provides a list of phonemes and their decomposition into distinctive features. This file is used to recognize phonological similarity and natural classes when creating and handling alternation patterns.
 
 To create a new segments file, the best is usually to refer to an authoritative description, and adapt it to the needs of the specific dataset. In the absence of such a description, I suggest to make use of `Bruce Hayes’ spreadsheet <https://linguistics.ucla.edu/people/hayes/120a/index.htm#features>`__ as a starting point (he writes ``+``, ``-`` and ``0`` for our ``1``,\ ``0`` and ``-1``).
 
@@ -13,10 +13,7 @@ Each row of the segments file describes a single phoneme. The first column gives
 
 
 .. warning::
-    The index header used to be `Seg.` (for segment). This is deprecated, and Qumin now expects `sound_id`, per the Paralex standard.
-
-.. warning::
-    The columns `ALIAS`, `UNICODE` and `value` are all also deprecated
+    The index header used to be `Seg.` (for segment), and Qumin expected two more columns `ALIAS` and `UNICODE`. This is not supported anymore, and Qumin now expects `sound_id`, per the Paralex standard.
 
  ========== ======== ============ =============== ========= ======= ====== ===== ========= ========= =========== ========= ======= ==========
   sound_id   sonant   syllabique   consonantique   continu   nasal   haut   bas   arrière   arrondi   antérieur   CORONAL   voisé   rel.ret.
@@ -45,12 +42,12 @@ Some conventions:
   b          0        0            1               0         0       0            0                   1                     1       0
  ========== ======== ============ =============== ========= ======= ====== ===== ========= ========= =========== ========= ======= ==========
 
-The file is encoded in utf-8 and can be either a csv table (preferred) or a tabulation separated table (tsv).
+The file is encoded in utf-8 and can must be a csv table (comma separated):
 
 .. code:: sh
 
    %%sh
-   head -n 6 "../Data/Vlexique/frenchipa.csv"
+   head -n 6 "../Data/Vlexique/vlexique_sounds.csv"
 
 ::
 
@@ -60,16 +57,16 @@ The file is encoded in utf-8 and can be either a csv table (preferred) or a tabu
    t,0,0,1,0,0,0,,0,,1,1,0,0
    d,0,0,1,0,0,0,,0,,1,1,1,0
 
-Segmentation and aliases
+Segmentation
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Inflected forms are now expected to be segmented in the input (using spaces to separate phonemes in words).
-The ALIAS column is not needed anymore.
+Per the Paralex standard, inflected forms are now expected to be segmented in the input (using spaces to separate phonemes in words).
 
 Shorthands
 ~~~~~~~~~~~
 
-Qumin used to support a second header row to provide distinctive feature shorthands. These are not supported anymore.
+.. warning::
+    Qumin used to support a second header row to provide distinctive feature shorthands. These are not supported anymore.
 
 One can provide some extra rows in the table to define shorthand names for some natural classes. These names have to start and end by “#”. Here an example for the French segments file, giving shorthands for C (consonants), V (vowels) and G (glides):
 
@@ -202,7 +199,7 @@ Internally, Qumin will replace all of these identical characters by a single uni
 Creating scales 
 >>>>>>>>>>>>>>>>>
 
-Rather than using many-valued features, it is often preferrable to use a few monovalent or bivalent features to create a scale. As an example, here is a possible (bad) implementation for tones, which uses a single feature "Tone". 
+Rather than using many-valued features, it is often preferable to use a few monovalent or bivalent features to create a scale. As an example, here is a possible (bad) implementation for tones, which uses a single feature "Tone".
 
 
 .. csv-table::

--- a/src/qumin/calc_paradigm_entropy.py
+++ b/src/qumin/calc_paradigm_entropy.py
@@ -130,3 +130,5 @@ def H_command(cfg, md):
                                  'content': 'results'})
     log.info("Writing to: {}".format(ent_file))
     distrib.export_file(ent_file)
+
+    return ent_file

--- a/src/qumin/cli.py
+++ b/src/qumin/cli.py
@@ -6,6 +6,7 @@ from .find_patterns import pat_command
 from .find_macroclasses import macroclasses_command
 from .make_lattice import lattice_command
 from .microclass_heatmap import heatmap_command
+from .entropy_heatmap import ent_heatmap_command
 from .eval import eval_command
 from .utils import Metadata
 
@@ -17,7 +18,8 @@ def qumin_command(cfg):
     log.info(cfg)
     md = Metadata(cfg, __file__)
 
-    if cfg.patterns is None or cfg.action == "patterns":
+    if (cfg.patterns is None or cfg.action == "patterns") and \
+            cfg.action != 'ent_heatmap':
         not_overab = cfg.pats.overabundant is False
         not_defect = cfg.pats.defective is False
         for_H = cfg.action == "H"
@@ -28,7 +30,7 @@ def qumin_command(cfg):
         cfg.patterns = patterns_file
 
     if cfg.action == "H":
-        H_command(cfg, md)
+        cfg.ent_hm.results = H_command(cfg, md)
     elif cfg.action == "macroclasses":
         macroclasses_command(cfg, md)
     elif cfg.action == "lattice":
@@ -37,5 +39,8 @@ def qumin_command(cfg):
         heatmap_command(cfg, md)
     elif cfg.action == "eval":
         eval_command(cfg, md)
+
+    if (cfg.action == "H" and cfg.ent_hm.enable) or cfg.action == 'ent_heatmap':
+        ent_heatmap_command(cfg, md)
 
     md.save_metadata()

--- a/src/qumin/cli.py
+++ b/src/qumin/cli.py
@@ -30,7 +30,7 @@ def qumin_command(cfg):
         cfg.patterns = patterns_file
 
     if cfg.action == "H":
-        cfg.ent_hm.results = H_command(cfg, md)
+        cfg.entropy.importFile = H_command(cfg, md)
     elif cfg.action == "macroclasses":
         macroclasses_command(cfg, md)
     elif cfg.action == "lattice":
@@ -40,7 +40,7 @@ def qumin_command(cfg):
     elif cfg.action == "eval":
         eval_command(cfg, md)
 
-    if (cfg.action == "H" and cfg.ent_hm.enable) or cfg.action == 'ent_heatmap':
+    if (cfg.action == "H" and cfg.entropy.heatmap) or cfg.action == 'ent_heatmap':
         ent_heatmap_command(cfg, md)
 
     md.save_metadata()

--- a/src/qumin/config/qumin.yaml
+++ b/src/qumin/config/qumin.yaml
@@ -26,7 +26,7 @@ hydra:
 
 disable_existing_loggers: false
 
-action: patterns      # Action, one of: patterns, H, lattice, eval, macroclasses, heatmap
+action: patterns      # Action, one of: patterns, H, lattice, eval, macroclasses, heatmap, ent_heatmap
 data: null            # path to paralex.package.json paradigms, segments
 cells: null           # List of cells to use (subset)
 patterns: null        # path to pre-computed patterns. If null, will compute patterns.
@@ -52,6 +52,18 @@ heatmap:
   exhaustive_labels: False # by default, seaborn shows only some labels on
                            # the heatmap for readability.
                            # This forces seaborn to print all labels.
+ent_hm:
+  enable: True            # Whether to draw a heatmap.
+  results: null            # A file with entropy computation results.
+  order: False             # Priority list for sorting features (ex: [number, case]) or an ordered list of the cells to display.
+  cmap: null               # colormap name
+  exhaustive_labels: False # by default, seaborn shows only some label
+                           # the heatmap for readability.
+                           # This forces seaborn to print all labels.
+  dense: False             # Use initials instead of full labels
+  annotate: False          # Display values on the heatmap.
+
+
 
 entropy:
   n:                  # Compute entropy for prediction from with n predictors.

--- a/src/qumin/config/qumin.yaml
+++ b/src/qumin/config/qumin.yaml
@@ -54,7 +54,9 @@ heatmap:
                            # This forces seaborn to print all labels.
   dense: False             # Use initials instead of full labels (only for entropy heatmap)
   annotate: False          # Display values on the heatmap. (only for entropy heatmap)
-  order: False             # Priority list for sorting features (for entropy heatmap, ex: [number, case]) or an ordered list of the cells to display.
+  order: False             # Priority list for sorting features (for entropy heatmap)
+                           # ex: [number, case]). If no features-values file available,
+                           # it should contain an ordered list of the cells to display.
 
 entropy:
   heatmap: True        # Whether to draw a heatmap.

--- a/src/qumin/config/qumin.yaml
+++ b/src/qumin/config/qumin.yaml
@@ -47,30 +47,25 @@ lattice:
   png: False          # Export as png
 
 heatmap:
-  label: null              # lexeme column to use as label (eg. inflection_class)
+  label: null              # lexeme column to use as label (for microclass heatmap, eg. inflection_class)
   cmap: null               # colormap name
   exhaustive_labels: False # by default, seaborn shows only some labels on
                            # the heatmap for readability.
                            # This forces seaborn to print all labels.
-ent_hm:
-  enable: True            # Whether to draw a heatmap.
-  results: null            # A file with entropy computation results.
-  order: False             # Priority list for sorting features (ex: [number, case]) or an ordered list of the cells to display.
-  cmap: null               # colormap name
-  exhaustive_labels: False # by default, seaborn shows only some label
-                           # the heatmap for readability.
-                           # This forces seaborn to print all labels.
-  dense: False             # Use initials instead of full labels
-  annotate: False          # Display values on the heatmap.
-
-
+  dense: False             # Use initials instead of full labels (only for entropy heatmap)
+  annotate: False          # Display values on the heatmap. (only for entropy heatmap)
+  order: False             # Priority list for sorting features (for entropy heatmap, ex: [number, case]) or an ordered list of the cells to display.
 
 entropy:
+  heatmap: True        # Whether to draw a heatmap.
+
   n:                  # Compute entropy for prediction from with n predictors.
     - 1
   features: null      # Feature column in the Lexeme table.
                       # Features will be considered known in conditional probabilities: P(X~Y|X,f1,f2...)
-  importFile: null    # Import entropy file with n-1 predictors (allows for acceleration on nPreds entropy computation).
+  importFile: null    # Import entropy file
+                      # with any file, use to compute entropy heatmap
+                      # with n-1 predictors, allows for acceleration on nPreds entropy computation.
   merged: False       # Whether identical columns are merged in the input.
   stacked: False      # whether to stack results in long form
 

--- a/src/qumin/entropy_heatmap.py
+++ b/src/qumin/entropy_heatmap.py
@@ -1,0 +1,185 @@
+# !usr/bin/python3
+# -*- coding: utf-8 -*-
+"""Show entropy results as heatmap
+
+Author: Jules Bouton.
+"""
+from matplotlib import pyplot as plt
+from matplotlib import cm as cm
+import pandas as pd
+import numpy as np
+import seaborn as sns
+import logging
+
+log = logging.getLogger()
+
+
+def get_features_order(features_file, results, sort_order=False):
+    """Returns an ordered list of the cells from a Paralex compliant
+    cell file."""
+    if features_file:
+        log.info("Reading features")
+        features = pd.read_csv(features_file, index_col=0)
+
+        df = results.reset_index()
+        cells = set(df.predictor.to_list() + df.predicted.to_list())
+        df_c = pd.DataFrame(index=list(cells))
+        for c in cells:
+            feat_order = {}
+
+            for f in c.split('.'):
+                feat_order[features.loc[f, 'feature']] = features.loc[f, 'canonical_order']
+            for f, v in feat_order.items():
+                df_c.loc[c, f] = v
+
+        if not sort_order:
+            sort_order = list(df_c.columns)
+        return df_c.sort_values(by=[x for x in sort_order], axis=0).index.to_list()
+    else:
+        if sort_order:
+            return sort_order
+        else:
+            raise ValueError("""If no features are passed,
+    the --order argument should contain an ordered list of cells.""")
+
+
+def entropy_heatmap(results, md, cmap_name=False,
+                    feat_order=None, dense=False, annotate=False,
+                    parameter=False):
+    """Make a FacetGrid heatmap of all metrics.
+
+    Arguments:
+        results (:class:`pandas:pandas.DataFrame`):
+            a results DataFrame as produced by calc_paradigm_entropy.
+        md (qumin.utils.Metadata): MetaData handler to get access to file location.
+        cmap_name (str): name of the cmap to use. Defaults to the following cubehelix
+            map, `sns.cubehelix_palette(start=2, rot=0.5, dark=0, light=1, as_cmap=True)`.
+        feat_order (List[str]): an ordered list of each cell name.
+            Used to sort the labels.
+        dense (bool): whether to use short cell names or not.
+        annotate (bool): whether to add an annotation overlay.
+    """
+
+    if not cmap_name:
+        cmap = sns.cubehelix_palette(start=2, rot=0.5, dark=0, light=1, as_cmap=True)
+    else:
+        cmap = plt.get_cmap(cmap_name)
+
+    log.info("Drawing...")
+
+    df = results[['measure', 'value', 'n_pairs']
+                 ].set_index('measure', append=True
+                             ).stack().reset_index()
+    df.rename(columns={"level_3": "type", 0: "value"}, inplace=True)
+
+    # Compute a suitable size for the heatmaps
+    height = 4 + round(len(df['predictor'].unique())/5)
+
+    def _draw_heatmap(*args, **kwargs):
+        """ Draws a heatmap in a FacetGrid with custom parameters
+        """
+
+        df = kwargs.pop('data')
+        annot = kwargs.pop('annotate')
+
+        # For n_pairs, we want a specific set of parameters.
+        if 'n_pairs' in list(df['type']):
+            hm_cmap = cmap
+            annot = True
+            fmt = ".0f"
+        else:
+            hm_cmap = cmap
+            fmt = ".2f"
+
+        df.index.name = 'predictor'
+        df.columns.name = 'predicted'
+        df = df.pivot(index=args[0], columns=args[1], values=args[2])
+
+        if feat_order:
+            df = df[feat_order]
+            df = df.reindex(feat_order)
+        else:
+            df = df.reindex(list(df.columns))
+
+        df = df.replace([np.nan], 0)
+
+        # Additional options for rendering.
+        # Extra short labels
+        if dense:
+            def shorten(x):
+                return ".".join([f[0].capitalize() for f in x.split('.')])
+
+            df.index = pd.Index(df.index.to_series().map(shorten))
+            df.columns = pd.Index(df.columns.to_series().map(shorten))
+
+        # Annotations on the heatmap
+        if annot:
+            annot = df.copy().round(2)
+
+        # Mask (diagonal)
+        df_m = pd.DataFrame(columns=df.columns, index=df.index)
+        for col in df.columns:
+            df_m.loc[df_m.index == col, [col]] = True
+
+        # Drawing each individual heatmap
+        sns.heatmap(df,
+                    annot=annot,
+                    mask=df_m,
+                    cmap=hm_cmap,
+                    fmt=fmt,
+                    linewidths=1,
+                    **kwargs)
+
+    # Plotting the heatmap
+    cg = sns.FacetGrid(df, row='measure', col='type', height=height, margin_titles=True)
+    cg.set_titles(row_template='{row_name}', col_template='{col_name}')
+
+    cg.map_dataframe(_draw_heatmap, 'predictor', 'predicted', 'value',
+                     annotate=annotate, square=True, cbar=False)
+
+    # Setting labels
+    rotate = 0 if dense else 90
+
+    cg.tick_params(axis='x', labelbottom=False, labeltop=True,
+                   bottom=False, top=True,
+                   labelrotation=rotate)
+    cg.tick_params(axis='y',
+                   labelrotation=0)
+
+    cg.set_ylabels('Predictor')
+    cg.set_xlabels('Predicted')
+
+    # We add a custom global colorbar
+    # The last value is the width
+    cbar_ax = cg.fig.add_axes([0.09, -0.04, 0.84, 0.04])
+    cbar = cg.fig.colorbar(cm.ScalarMappable(norm=None, cmap=cmap),
+                           cax=cbar_ax,
+                           drawedges=False,
+                           orientation='horizontal'
+                           )
+    cbar.set_ticks([0, 0.5, 1])
+    cbar.set_ticklabels(['Low', 'Balanced', 'High'])
+    cbar.outline.set_visible(False)
+
+    name = md.register_file("entropyHeatmap.png",
+                            {"computation": "entropy_heatmap",
+                             "content": "figure"})
+
+    log.info("Writing heatmap to: " + name)
+    cg.tight_layout()
+    cg.savefig(name, pad_inches=0.1)
+
+
+def ent_heatmap_command(cfg, md):
+    r"""Draw a heatmap of results similarities using seaborn.
+    """
+    log.info("Drawing a heatmap of the results...")
+    results = pd.read_csv(cfg.ent_hm.results, index_col=[0, 1])
+    features_file_name = md.get_table_path("features-values")
+    feat_order = get_features_order(features_file_name, results, cfg.ent_hm.order)
+
+    entropy_heatmap(results, md,
+                    cmap_name=cfg.ent_hm.cmap,
+                    feat_order=feat_order,
+                    dense=cfg.ent_hm.dense,
+                    annotate=cfg.ent_hm.annotate)

--- a/src/qumin/entropy_heatmap.py
+++ b/src/qumin/entropy_heatmap.py
@@ -6,6 +6,7 @@ Author: Jules Bouton.
 """
 from matplotlib import pyplot as plt
 from matplotlib import cm as cm
+from frictionless.exception import FrictionlessException
 import pandas as pd
 import numpy as np
 import seaborn as sns
@@ -39,13 +40,15 @@ def get_features_order(features_file, results, sort_order=False):
         if sort_order:
             return sort_order
         else:
-            raise ValueError("""If no features are passed,
-    the --order argument should contain an ordered list of cells.""")
+            log.warning("""No cells order provided. Falling back to alphabetical order.""")
+            df = results.reset_index()
+            return sorted(list(df.predictor.unique()))
 
 
 def entropy_heatmap(results, md, cmap_name=False,
                     feat_order=None, dense=False, annotate=False,
                     parameter=False):
+
     """Make a FacetGrid heatmap of all metrics.
 
     Arguments:
@@ -180,7 +183,12 @@ def ent_heatmap_command(cfg, md):
     """
     log.info("Drawing a heatmap of the results...")
     results = pd.read_csv(cfg.entropy.importFile, index_col=[0, 1])
-    features_file_name = md.get_table_path("features-values")
+    try:
+        features_file_name = md.get_table_path("features-val")
+    except FrictionlessException:
+        features_file_name = None
+        log.warning("Your package doesn't contain any features-values file. You should provide an ordered list of cells in command line.")
+
     feat_order = get_features_order(features_file_name, results, cfg.heatmap.order)
 
     entropy_heatmap(results, md,

--- a/src/qumin/entropy_heatmap.py
+++ b/src/qumin/entropy_heatmap.py
@@ -49,6 +49,7 @@ def entropy_heatmap(results, md, cmap_name=False,
     """Make a FacetGrid heatmap of all metrics.
 
     Arguments:
+        parameter: ## What is this ? ##
         results (:class:`pandas:pandas.DataFrame`):
             a results DataFrame as produced by calc_paradigm_entropy.
         md (qumin.utils.Metadata): MetaData handler to get access to file location.
@@ -174,12 +175,12 @@ def ent_heatmap_command(cfg, md):
     r"""Draw a heatmap of results similarities using seaborn.
     """
     log.info("Drawing a heatmap of the results...")
-    results = pd.read_csv(cfg.ent_hm.results, index_col=[0, 1])
+    results = pd.read_csv(cfg.entropy.importFile, index_col=[0, 1])
     features_file_name = md.get_table_path("features-values")
-    feat_order = get_features_order(features_file_name, results, cfg.ent_hm.order)
+    feat_order = get_features_order(features_file_name, results, cfg.heatmap.order)
 
     entropy_heatmap(results, md,
-                    cmap_name=cfg.ent_hm.cmap,
+                    cmap_name=cfg.heatmap.cmap,
                     feat_order=feat_order,
-                    dense=cfg.ent_hm.dense,
-                    annotate=cfg.ent_hm.annotate)
+                    dense=cfg.heatmap.dense,
+                    annotate=cfg.heatmap.annotate)

--- a/src/qumin/entropy_heatmap.py
+++ b/src/qumin/entropy_heatmap.py
@@ -72,6 +72,8 @@ def entropy_heatmap(results, md, cmap_name=False,
                  ].set_index('measure', append=True
                              ).stack().reset_index()
     df.rename(columns={"level_3": "type", 0: "value"}, inplace=True)
+    df.loc[:, 'type'] = df.type.replace({'value': 'Result', 'n_pairs': 'Number of pairs'})
+    df.loc[:, 'measure'] = df.measure.replace({'cond_entropy': 'Conditional entropy'})
 
     # Compute a suitable size for the heatmaps
     height = 4 + round(len(df['predictor'].unique())/5)
@@ -84,7 +86,7 @@ def entropy_heatmap(results, md, cmap_name=False,
         annot = kwargs.pop('annotate')
 
         # For n_pairs, we want a specific set of parameters.
-        if 'n_pairs' in list(df['type']):
+        if 'Number of pairs' in list(df['type']):
             hm_cmap = cmap
             annot = True
             fmt = ".0f"
@@ -149,6 +151,8 @@ def entropy_heatmap(results, md, cmap_name=False,
 
     cg.set_ylabels('Predictor')
     cg.set_xlabels('Predicted')
+
+    cg.fig.suptitle(f"Measured on the {md.datasets[0].name} dataset, version {md.datasets[0].version}")
 
     # We add a custom global colorbar
     # The last value is the width

--- a/src/qumin/entropy_heatmap.py
+++ b/src/qumin/entropy_heatmap.py
@@ -141,7 +141,9 @@ def entropy_heatmap(results, md, cmap_name=False,
     cg.set_titles(row_template='{row_name}', col_template='{col_name}')
 
     cg.map_dataframe(_draw_heatmap, 'predictor', 'predicted', 'value',
-                     annotate=annotate, square=True, cbar=False)
+                     annotate=annotate, square=True, cbar=True,
+                     cbar_kws=dict(location='bottom',
+                                   shrink=0.6))
 
     # Setting labels
     rotate = 0 if dense else 90
@@ -152,29 +154,28 @@ def entropy_heatmap(results, md, cmap_name=False,
     cg.tick_params(axis='y',
                    labelrotation=0)
 
+    # Override general tick settings.
+    for row in cg.axes:
+        for hm in row:
+            cb = hm.collections[-1].colorbar
+            cb.outline.set_visible(True)
+            cb.outline.set_linewidth(0.5)
+            cb.ax.tick_params(labelbottom=True, labeltop=False,
+                              bottom=True, top=False,
+                              labelrotation=0)
+
     cg.set_ylabels('Predictor')
     cg.set_xlabels('Predicted')
-
     cg.fig.suptitle(f"Measured on the {md.datasets[0].name} dataset, version {md.datasets[0].version}")
 
-    # We add a custom global colorbar
-    # The last value is the width
-    cbar_ax = cg.fig.add_axes([0.09, -0.04, 0.84, 0.04])
-    cbar = cg.fig.colorbar(cm.ScalarMappable(norm=None, cmap=cmap),
-                           cax=cbar_ax,
-                           drawedges=False,
-                           orientation='horizontal'
-                           )
-    cbar.set_ticks([0, 0.5, 1])
-    cbar.set_ticklabels(['Low', 'Balanced', 'High'])
-    cbar.outline.set_visible(False)
+    cg.tight_layout()
 
     name = md.register_file("entropyHeatmap.png",
                             {"computation": "entropy_heatmap",
                              "content": "figure"})
 
     log.info("Writing heatmap to: " + name)
-    cg.tight_layout()
+
     cg.savefig(name, pad_inches=0.1)
 
 

--- a/src/qumin/entropy_heatmap.py
+++ b/src/qumin/entropy_heatmap.py
@@ -85,7 +85,7 @@ def entropy_heatmap(results, md, cmap_name=False,
         df.measure += df.n_preds.apply(lambda x: f" (n={x})")
 
     # Compute a suitable size for the heatmaps
-    height = 4 + round(len(df['predictor'].unique())/5)
+    height = 4 + round(len(df['predictor'].unique())/4)
 
     def _draw_heatmap(*args, **kwargs):
         """ Draws a heatmap in a FacetGrid with custom parameters
@@ -94,18 +94,20 @@ def entropy_heatmap(results, md, cmap_name=False,
         df = kwargs.pop('data')
         annot = kwargs.pop('annotate')
 
+        types = df["type"].unique()
+        df.index.name = 'predictor'
+        df.columns.name = 'predicted'
+        df = df.pivot(index=args[0], columns=args[1], values=args[2])
+
         # For n_pairs, we want a specific set of parameters.
-        if 'Number of pairs' in list(df['type']):
-            hm_cmap = cmap
-            annot = True
+        if 'Number of pairs' in types:
+            hm_cmap = "gray_r"
+            annot = df.shape[0] < 10
             fmt = ".0f"
         else:
             hm_cmap = cmap
             fmt = ".2f"
 
-        df.index.name = 'predictor'
-        df.columns.name = 'predicted'
-        df = df.pivot(index=args[0], columns=args[1], values=args[2])
         if feat_order:
 
             # Sorting for multiple predictors.

--- a/src/qumin/entropy_heatmap.py
+++ b/src/qumin/entropy_heatmap.py
@@ -185,7 +185,7 @@ def ent_heatmap_command(cfg, md):
     log.info("Drawing a heatmap of the results...")
     results = pd.read_csv(cfg.entropy.importFile, index_col=[0, 1])
     try:
-        features_file_name = md.get_table_path("features-val")
+        features_file_name = md.get_table_path("features-values")
     except FrictionlessException:
         features_file_name = None
         log.warning("Your package doesn't contain any features-values file. You should provide an ordered list of cells in command line.")


### PR DESCRIPTION
As discussed in #28 , this introduces a new feature: automatic heatmap drawing based on the results of entropy computations.

Behaviour of the CLI interface:
- Runs automatically at the end of any entropy computation
- I kept a handy CLI action, because it can be useful to rerun the heatmap with different parameters but not the full pipeline, since it can be quite long for big datasets.

The heatmaps produce contain both the entropy heatmap and the n_pairs column. All the details are in the main doc file.

A small issue: the name `heatmap` in hydra is already taken by another action, so I went for `ent_heatmap` and a shorter `ent_hm` for parameters. Do you prefer some other name? (`H_heatmap` ?)