### PR TITLE
Unique id's in the Form class

### DIFF
--- a/src/qumin/representations/__init__.py
+++ b/src/qumin/representations/__init__.py
@@ -166,7 +166,7 @@ def create_paradigms(dataset, fillna=True,
     def parse_cell(cell):
         if not cell:
             return cell
-        forms = [Form(form_dic[f], f) for f in cell]
+        forms = [Form(form_dic[f], form_id=f) for f in cell]
         if overabundant:
             forms = tuple(sorted(forms))
         else:

--- a/src/qumin/representations/__init__.py
+++ b/src/qumin/representations/__init__.py
@@ -103,8 +103,8 @@ def create_paradigms(dataset, fillna=True,
         paradigms = paradigms.sample(sample)
 
     def aggregator(s):
-        tpl = tuple(s[s.apply(lambda x: form_dic[x] != '')])
-        return tpl if len(tpl) > 0 else ""
+        form_ids = tuple(form_id for form_id in s if form_dic[form_id] != '')
+        return form_ids if len(form_ids) > 0 else ""
 
     def check_cells(cells, par_cols):
         unknown_cells = set(cells) - set(par_cols)

--- a/src/qumin/representations/segments.py
+++ b/src/qumin/representations/segments.py
@@ -59,7 +59,6 @@ class Form(str):
         stripped = segmented.strip(" ")
         self = str.__new__(cls, stripped + " ")
         self.tokens = stripped.split()
-        self.id = None
         return self
 
     def __repr__(self):

--- a/src/qumin/representations/segments.py
+++ b/src/qumin/representations/segments.py
@@ -63,7 +63,7 @@ class Form(str):
         return self
 
     def __repr__(self):
-        return f"Form({self}, id:{self.id})"
+        return f"Form({self}, id:{self.id})" if self.id else f"Form({self})"
 
 
 class Inventory(object):

--- a/src/qumin/representations/segments.py
+++ b/src/qumin/representations/segments.py
@@ -40,17 +40,18 @@ class Form(str):
 
     Attributes:
         tokens (Tuple): Tuple of phonemes contained in this form
-        id (str): form_id of the corresponding form according to the Paralex package
+        id (str): form_id of the corresponding form according to the Paralex package.
+            If unknown, `None` will be assigned.
     """
 
-    def __new__(cls, string, fid):
+    def __new__(cls, string, form_id=None):
         tokens = Inventory._segmenter.findall(string)
         tokens = tuple(Inventory._normalization.get(c, c) for c in tokens)
         if Inventory._legal_str.fullmatch("".join(tokens)) is None:
             raise ValueError("Unknown sound in: " + repr(string))
         self = str.__new__(cls, " ".join(tokens) + " ")
         self.tokens = tokens
-        self.id = fid
+        self.id = form_id
         return self
 
     @classmethod
@@ -58,6 +59,7 @@ class Form(str):
         stripped = segmented.strip(" ")
         self = str.__new__(cls, stripped + " ")
         self.tokens = stripped.split()
+        self.id = None
         return self
 
     def __repr__(self):

--- a/src/qumin/representations/segments.py
+++ b/src/qumin/representations/segments.py
@@ -37,16 +37,20 @@ class Form(str):
 
     Sounds might be more than one character long.
     Forms are strings, they are segmented at the object creation.
-    They have a tokens attribute, which is a tuple of phonemes.
+
+    Attributes:
+        tokens (Tuple): Tuple of phonemes contained in this form
+        id (str): form_id of the corresponding form according to the Paralex package
     """
 
-    def __new__(cls, string):
+    def __new__(cls, string, fid):
         tokens = Inventory._segmenter.findall(string)
         tokens = tuple(Inventory._normalization.get(c, c) for c in tokens)
         if Inventory._legal_str.fullmatch("".join(tokens)) is None:
             raise ValueError("Unknown sound in: " + repr(string))
         self = str.__new__(cls, " ".join(tokens) + " ")
         self.tokens = tokens
+        self.id = fid
         return self
 
     @classmethod
@@ -57,7 +61,7 @@ class Form(str):
         return self
 
     def __repr__(self):
-        return "Form(" + self + ")"
+        return f"Form({self}, id:{self.id})"
 
 
 class Inventory(object):


### PR DESCRIPTION
I will start several small PR, feature by feature. Since they depend on each other, I will wait for the first one to be merged before opening the next ones.

This feature introduces a new attribute for the Form class: the form id. It is now possible to retrieve the form id of a Form object at any stage of the process. For instance, it makes it possible to access the frequency of a form through it's form_id in the frequency table, at very late steps.

The nice thing is that identity assertions still hold, because `Form()` inherits it's `__eq__` from `str`, and string equality doesn't check the `Form.id` attribute.

The tricky part concerns the step where the paradigm is built (`create_paradigm`), because we need to store the form_id instead of the phon_form until we create the Form() object (at the end), so I needed a dictionary to access the phon_form inbetween.

Since this pertains to Qumin's core classes, I suggest triple-checking my code before merging...