### PR TITLE
fix sampling, refactor args, improve log

### DIFF
--- a/sphinx/patterns.rst
+++ b/sphinx/patterns.rst
@@ -10,8 +10,10 @@ The patterns can be further configured, modifying the following keys: ::
     cells: null               # List of cells to use (subset)
     pos: null                 # List of parts of speech to use (subset)
     patterns: null            # path to pre-computed patterns. If null, will compute patterns.
-    most_freq: null           # (int) restrict to N most frequent items (use the lexeme "frequency" column)
-    sample: null              # ( int) A number of lexemes to sample, for debug purposes
+    sample: null              # (int) A number of lexemes to sample, for debug purposes.
+                              # Samples by frequency if possible, otherwise randomly.
+    force_random: False       # Whether to force random sampling.
+    seed: 1                   # Random seed for reproducible random effects.
     pats:
       kind: phon   # Options are (see docs): phon, edits
       defective: False        # Whether to keep defective entries

--- a/src/qumin/calc_paradigm_entropy.py
+++ b/src/qumin/calc_paradigm_entropy.py
@@ -45,7 +45,7 @@ def H_command(cfg, md):
                           pos=cfg.pos,
                           force=cfg.force,
                           sample=cfg.sample,
-                          sample_kws=dict(most_freq=cfg.most_freq,
+                          sample_kws=dict(force_random=cfg.force_random,
                                           seed=cfg.seed),
                           )
     patterns = ParadigmPatterns()

--- a/src/qumin/calc_paradigm_entropy.py
+++ b/src/qumin/calc_paradigm_entropy.py
@@ -36,14 +36,18 @@ def H_command(cfg, md):
     segments.Inventory.initialize(sounds_file_name)
 
     # Inflectional paradigms: rows are forms, with lexeme and cell..
-    paradigms = Paradigms(md.dataset, defective=defective, overabundant=False,
+    paradigms = Paradigms(md.dataset,
+                          defective=defective,
+                          overabundant=False,
                           merge_cols=cfg.entropy.merged,
-                          segcheck=True, cells=cells, pos=cfg.pos,
-                          sample=cfg.sample,
-                          most_freq=cfg.most_freq,
+                          segcheck=True,
+                          cells=cells,
+                          pos=cfg.pos,
                           force=cfg.force,
+                          sample=cfg.sample,
+                          sample_kws=dict(most_freq=cfg.most_freq,
+                                          seed=cfg.seed),
                           )
-
     patterns = ParadigmPatterns()
     patterns.from_file(patterns_folder_path,
                        paradigms.data,

--- a/src/qumin/config/qumin.yaml
+++ b/src/qumin/config/qumin.yaml
@@ -31,10 +31,11 @@ data: null            # path to paralex.package.json paradigms, segments
 cells: null           # List of cells to use (subset)
 pos: null             # List of parts of speech to use (subset)
 patterns: null        # path to pre-computed patterns. If null, will compute patterns.
-sample: null          # (int) A number of lexemes to sample, for debug purposes
-most_freq: True       # Whether to sample on frequency (if available) or randomly.
-force: False          # Whether to overpass RAM usage security (2GB)
+sample: null          # (int) A number of lexemes to sample, for debug purposes.
+                      # Samples by frequency if possible, otherwise randomly.
+force_random: False   # Whether to force random sampling.
 seed: 1               # Random seed for reproducible random effects.
+force: False          # Whether to overpass RAM usage security (2GB)
 cpus: null            # Number of cpus to use for big computations
                       # (defaults to the number of available cpus - 2).
 

--- a/src/qumin/config/qumin.yaml
+++ b/src/qumin/config/qumin.yaml
@@ -31,8 +31,8 @@ data: null            # path to paralex.package.json paradigms, segments
 cells: null           # List of cells to use (subset)
 pos: null             # List of parts of speech to use (subset)
 patterns: null        # path to pre-computed patterns. If null, will compute patterns.
-most_freq: null       # restrict to N most frequent items (use the lexeme "frequency" column)
 sample: null          # (int) A number of lexemes to sample, for debug purposes
+most_freq: True       # Whether to sample on frequency (if available) or randomly.
 force: False          # Whether to overpass RAM usage security (2GB)
 cpus: null            # Number of cpus to use for big computations
                       # (defaults to the number of available cpus - 2).

--- a/src/qumin/config/qumin.yaml
+++ b/src/qumin/config/qumin.yaml
@@ -34,6 +34,7 @@ patterns: null        # path to pre-computed patterns. If null, will compute pat
 sample: null          # (int) A number of lexemes to sample, for debug purposes
 most_freq: True       # Whether to sample on frequency (if available) or randomly.
 force: False          # Whether to overpass RAM usage security (2GB)
+seed: 1               # Random seed for reproducible random effects.
 cpus: null            # Number of cpus to use for big computations
                       # (defaults to the number of available cpus - 2).
 

--- a/src/qumin/eval.py
+++ b/src/qumin/eval.py
@@ -186,7 +186,7 @@ def prepare_data(cfg, md):
                           overabundant=cfg.pats.overabundant,
                           defective=cfg.pats.defective,
                           sample=cfg.sample,
-                          most_freq=cfg.most_freq
+                          force_random=cfg.force_random
                           )
     indexes = paradigms.index
     features = None

--- a/src/qumin/find_patterns.py
+++ b/src/qumin/find_patterns.py
@@ -38,9 +38,10 @@ def pat_command(cfg, md):
                           segcheck=segcheck,
                           cells=cells,
                           pos=cfg.pos,
-                          sample=cfg.sample,
-                          most_freq=cfg.most_freq,
                           force=cfg.force,
+                          sample=cfg.sample,
+                          sample_kws=dict(most_freq=cfg.most_freq,
+                                          seed=cfg.seed),
                           )
 
     log.info("Looking for patterns...")

--- a/src/qumin/find_patterns.py
+++ b/src/qumin/find_patterns.py
@@ -40,7 +40,7 @@ def pat_command(cfg, md):
                           pos=cfg.pos,
                           force=cfg.force,
                           sample=cfg.sample,
-                          sample_kws=dict(most_freq=cfg.most_freq,
+                          sample_kws=dict(force_random=cfg.force_random,
                                           seed=cfg.seed),
                           )
 

--- a/src/qumin/representations/frequencies.py
+++ b/src/qumin/representations/frequencies.py
@@ -133,7 +133,7 @@ class Frequencies(object):
 
         # 3. For cells and lexemes build from the forms table.
         # TODO read directly from the frequencies table if possible
-        elif not force_uniform and name != 'forms' and (self.source['forms'] != "empty"):
+        elif not force_uniform and name != 'forms' and (self.has_frequencies('forms')):
             log.info(f'{name}: No frequencies in the {name} table, building from the forms table.')
             freq = self.forms.groupby(name[:-1]).value.sum()
             table.loc[freq.index, "value"] = freq.values
@@ -358,6 +358,16 @@ class Frequencies(object):
             setattr(self, data, _selector(mapping))
         else:
             return _selector(mapping)
+
+    def has_frequencies(self, table="forms"):
+        """
+        Returns True if the requested contains real frequencies.
+
+        Parameters:
+            table (str): name of the table to test.
+        """
+
+        return self.source[table] != "empty"
 
     def info(self):
         """Returns a convenient DataFrame with summary statistics.

--- a/src/qumin/representations/patterns.py
+++ b/src/qumin/representations/patterns.py
@@ -1068,7 +1068,7 @@ class ParadigmPatterns(dict):
 
         if (
                 defective
-                and (paradigms.form == '').any()
+                and (paradigms[paradigms.cell.isin(cells)].form == '').any()
                 and table.pattern.notna().all()
         ):
             raise ValueError("It looks like you ignored defective rows"


### PR DESCRIPTION
Opening a PR, as this slightly changes the interface.

- The doc said that sampling=100 was sampling on lexemes, but it was actually using forms (due to long format) -> Fixed
-  sampling and most_freq were quite redundant. I suggest using sampling to set the number of lexemes to keep, the use lexeme frequencies if available, and fall back to random sampling if no frequencies. Most_freq=False forces random sampling (but maybe random=True would be a better semantic ?)
- frequency sampling now uses the Frequency API.

I used this opportunity to clean up the preprocess function and split it into several methods