### PR TITLE
Add token frequencies for patterns

### DIFF
--- a/src/qumin/calc_paradigm_entropy.py
+++ b/src/qumin/calc_paradigm_entropy.py
@@ -73,17 +73,20 @@ def H_command(cfg, md):
     patterns.info()
 
     distrib = PatternDistribution(patterns,
-                                  md.dataset,
+                                  md.dataset.name,
+                                  paradigms.frequencies,
                                   features=features)
 
     if onePred:
         if verbose:
             distrib.one_pred_entropy(debug=verbose,
                                      legacy=cfg.entropy.legacy,
-                                     tokens=cfg.entropy.tokens.patterns,
+                                     token_patterns=cfg.entropy.tokens.patterns,
+                                     token_predictors=cfg.entropy.tokens.predictors,
                                      )
         distrib.one_pred_entropy(legacy=cfg.entropy.legacy,
-                                 tokens=cfg.entropy.tokens.patterns,
+                                 token_patterns=cfg.entropy.tokens.patterns,
+                                 token_predictors=cfg.entropy.tokens.predictors,
                                  )
         mean = distrib.get_results().loc[:, "value"].mean()
         log.info("Mean H(c1 -> c2) = %s ", mean)

--- a/src/qumin/calc_paradigm_entropy.py
+++ b/src/qumin/calc_paradigm_entropy.py
@@ -25,10 +25,12 @@ def H_command(cfg, md):
     sounds_file_name = md.get_table_path("sounds")
     defective = cfg.pats.defective
 
-    assert not (cfg.entropy.tokens.patterns and cfg.entropy.legacy), \
-        "Token weighting of the patterns are not available with legacy computation."
+    assert not ((cfg.entropy.tokens.patterns or cfg.entropy.tokens.patterns) and cfg.entropy.legacy), \
+        "Tokens can't be used in entropy computations with legacy=True."
 
     preds = [cfg.entropy.n] if type(cfg.entropy.n) is int else sorted(cfg.entropy.n)
+    assert (preds[-1] == 1 or cfg.entropy.legacy), \
+        "N predictor computations are only available with legacy=True"
     onePred = preds[0] == 1
     if onePred:
         preds.pop(0)

--- a/src/qumin/calc_paradigm_entropy.py
+++ b/src/qumin/calc_paradigm_entropy.py
@@ -25,8 +25,9 @@ def H_command(cfg, md):
     sounds_file_name = md.get_table_path("sounds")
     defective = cfg.pats.defective
 
-    assert not ((cfg.entropy.tokens.patterns or cfg.entropy.tokens.patterns) and cfg.entropy.legacy), \
-        "Tokens can't be used in entropy computations with legacy=True."
+    assert not ((cfg.entropy.token_freq.patterns or cfg.entropy.token_freq.patterns)
+                and cfg.entropy.legacy), \
+        "Token frequencies can't be used in entropy computations with legacy=True."
 
     preds = [cfg.entropy.n] if type(cfg.entropy.n) is int else sorted(cfg.entropy.n)
     assert (preds[-1] == 1 or cfg.entropy.legacy), \
@@ -83,12 +84,12 @@ def H_command(cfg, md):
         if verbose:
             distrib.one_pred_entropy(debug=verbose,
                                      legacy=cfg.entropy.legacy,
-                                     token_patterns=cfg.entropy.tokens.patterns,
-                                     token_predictors=cfg.entropy.tokens.predictors,
+                                     token_patterns=cfg.entropy.token_freq.patterns,
+                                     token_predictors=cfg.entropy.token_freq.predictors,
                                      )
         distrib.one_pred_entropy(legacy=cfg.entropy.legacy,
-                                 token_patterns=cfg.entropy.tokens.patterns,
-                                 token_predictors=cfg.entropy.tokens.predictors,
+                                 token_patterns=cfg.entropy.token_freq.patterns,
+                                 token_predictors=cfg.entropy.token_freq.predictors,
                                  )
         mean = distrib.get_results().loc[:, "value"].mean()
         log.info("Mean H(c1 -> c2) = %s ", mean)

--- a/src/qumin/calc_paradigm_entropy.py
+++ b/src/qumin/calc_paradigm_entropy.py
@@ -23,15 +23,13 @@ def H_command(cfg, md):
     patterns_folder_path = cfg.patterns
     sounds_file_name = md.get_table_path("sounds")
     defective = cfg.pats.defective
-
-    assert not ((cfg.entropy.token_freq.patterns or cfg.entropy.token_freq.patterns)
-                and cfg.entropy.legacy), \
-        "Token frequencies can't be used in entropy computations with legacy=True."
-
     preds = [cfg.entropy.n] if type(cfg.entropy.n) is int else sorted(cfg.entropy.n)
-    assert (preds[-1] == 1 or cfg.entropy.legacy), \
-        "N predictor computations are only available with legacy=True"
     onePred = preds[0] == 1
+    legacy = not (cfg.entropy.token_freq.patterns or cfg.entropy.token_freq.patterns)
+
+    assert legacy or (preds[-1] == 1), \
+        "Token frequencies can't be used in N predictor computations, except for weighting cells."
+
     if onePred:
         preds.pop(0)
 
@@ -82,11 +80,11 @@ def H_command(cfg, md):
     if onePred:
         if verbose:
             distrib.one_pred_entropy(debug=verbose,
-                                     legacy=cfg.entropy.legacy,
+                                     legacy=legacy,
                                      token_patterns=cfg.entropy.token_freq.patterns,
                                      token_predictors=cfg.entropy.token_freq.predictors,
                                      )
-        distrib.one_pred_entropy(legacy=cfg.entropy.legacy,
+        distrib.one_pred_entropy(legacy=legacy,
                                  token_patterns=cfg.entropy.token_freq.patterns,
                                  token_predictors=cfg.entropy.token_freq.predictors,
                                  )

--- a/src/qumin/calc_paradigm_entropy.py
+++ b/src/qumin/calc_paradigm_entropy.py
@@ -25,6 +25,9 @@ def H_command(cfg, md):
     sounds_file_name = md.get_table_path("sounds")
     defective = cfg.pats.defective
 
+    assert not (cfg.entropy.tokens.patterns and cfg.entropy.legacy), \
+        "Token weighting of the patterns are not available with legacy computation."
+
     preds = [cfg.entropy.n] if type(cfg.entropy.n) is int else sorted(cfg.entropy.n)
     onePred = preds[0] == 1
     if onePred:
@@ -70,13 +73,18 @@ def H_command(cfg, md):
     patterns.info()
 
     distrib = PatternDistribution(patterns,
-                                  md.dataset.name,
+                                  md.dataset,
                                   features=features)
 
     if onePred:
         if verbose:
-            distrib.one_pred_entropy(debug=verbose)
-        distrib.one_pred_entropy()
+            distrib.one_pred_entropy(debug=verbose,
+                                     legacy=cfg.entropy.legacy,
+                                     tokens=cfg.entropy.tokens.patterns,
+                                     )
+        distrib.one_pred_entropy(legacy=cfg.entropy.legacy,
+                                 tokens=cfg.entropy.tokens.patterns,
+                                 )
         mean = distrib.get_results().loc[:, "value"].mean()
         log.info("Mean H(c1 -> c2) = %s ", mean)
 

--- a/src/qumin/config/qumin.yaml
+++ b/src/qumin/config/qumin.yaml
@@ -74,8 +74,7 @@ entropy:
                       # with any file, use to compute entropy heatmap
                       # with n-1 predictors, allows for acceleration on nPreds entropy computation.
   merged: False       # Whether identical columns are merged in the input.
-  legacy: False       # Whether to use the legacy calculation. Slightly slower, but less options.
-  token_freq:         # [incompatible with legacy] Whether to use token frequencies for...
+  token_freq:         # Whether to use token frequencies for...
     patterns: False   # The probability of the patterns.
     predictors: False # The probability of the predictor classes and of the predictor forms.
     cells: False      # The weighting of the measures across different cells.

--- a/src/qumin/config/qumin.yaml
+++ b/src/qumin/config/qumin.yaml
@@ -75,7 +75,7 @@ entropy:
   merged: False       # Whether identical columns are merged in the input.
   stacked: False      # Whether to stack results in long form
   legacy: False       # Whether to use the legacy calculation. Slightly slower, but less options.
-  tokens:             # [incompatible with legacy] Whether to use token frequencies for...
+  token_freq:         # [incompatible with legacy] Whether to use token frequencies for...
     patterns: False   # The probability of the patterns.
     predictors: False # The probability of the predictor classes and of the predictor forms.
     cells: False      # The weighting of the measures across different cells.

--- a/src/qumin/config/qumin.yaml
+++ b/src/qumin/config/qumin.yaml
@@ -76,7 +76,8 @@ entropy:
   stacked: False      # Whether to stack results in long form
   legacy: False       # Whether to use the legacy calculation. Slightly slower, but less options.
   tokens:             # Whether to use token frequencies for...
-    patterns: True    # The probability of the patterns and the weighting of the predictors.
+    patterns: True    # The probability of the patterns.
+    predictors: True  # The probability of the predictor classes and of the predictor forms.
     cells: True       # The weighting of the measures across different cells.
 
 eval:

--- a/src/qumin/config/qumin.yaml
+++ b/src/qumin/config/qumin.yaml
@@ -73,7 +73,11 @@ entropy:
                       # with any file, use to compute entropy heatmap
                       # with n-1 predictors, allows for acceleration on nPreds entropy computation.
   merged: False       # Whether identical columns are merged in the input.
-  stacked: False      # whether to stack results in long form
+  stacked: False      # Whether to stack results in long form
+  legacy: False       # Whether to use the legacy calculation. Slightly slower, but less options.
+  tokens:             # Whether to use token frequencies for...
+    patterns: True    # The probability of the patterns and the weighting of the predictors.
+    cells: True       # The weighting of the measures across different cells.
 
 eval:
   iter: 10            # How many 90/10 train/test folds to do.

--- a/src/qumin/config/qumin.yaml
+++ b/src/qumin/config/qumin.yaml
@@ -75,10 +75,10 @@ entropy:
   merged: False       # Whether identical columns are merged in the input.
   stacked: False      # Whether to stack results in long form
   legacy: False       # Whether to use the legacy calculation. Slightly slower, but less options.
-  tokens:             # Whether to use token frequencies for...
-    patterns: True    # The probability of the patterns.
-    predictors: True  # The probability of the predictor classes and of the predictor forms.
-    cells: True       # The weighting of the measures across different cells.
+  tokens:             # [incompatible with legacy] Whether to use token frequencies for...
+    patterns: False   # The probability of the patterns.
+    predictors: False # The probability of the predictor classes and of the predictor forms.
+    cells: False      # The weighting of the measures across different cells.
 
 eval:
   iter: 10            # How many 90/10 train/test folds to do.

--- a/src/qumin/entropy/__init__.py
+++ b/src/qumin/entropy/__init__.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 
-def P(x, subset=None):
+def P(x, weights=None, subset=None):
     """Return the probability distribution of elements in a :class:`pandas.core.series.Series`.
 
     Arguments:
@@ -14,6 +14,8 @@ def P(x, subset=None):
     Returns:
         :class:`pandas.core.series.Series`: A Series which index are x's elements and which values are their probability in x.
     """
+    if weights is not None:
+        return weights.groupby(x).sum() / weights.sum()
     if subset is None:
         return x.value_counts(normalize=True, sort=False)
     else:
@@ -63,3 +65,15 @@ def entropy(A):
     Return:
         H(A)"""
     return -(A * np.log2(A)).sum()
+
+
+def cond_entropy_slow(df, subset=None):
+    """
+    Calculate the conditional entropy through a slower method (with iterations across all groups).
+
+    Uses token frequencies to weight the patterns.
+    """
+    def compute_group_ent(group):
+        return entropy(P(group.pattern, weights=group.w_pair)) * group.w_x.sum()
+
+    return 0 + df.groupby('applicable').apply(compute_group_ent).sum() / df.w_x.sum()

--- a/src/qumin/entropy/__init__.py
+++ b/src/qumin/entropy/__init__.py
@@ -2,6 +2,7 @@
 # !/usr/bin/python3
 
 import numpy as np
+import pandas as pd
 
 
 def P(x, weights=None, subset=None):
@@ -9,6 +10,16 @@ def P(x, weights=None, subset=None):
     Return the probability distribution of unique elements in a :class:`pandas.core.series.Series`.
     The default is a Uniform probability distribution, where each token in `x` has the same
     probability. If weights are provided, they will be used as the probability of the tokens.
+
+    Example:
+        >>> P(pd.Series(["A", "B", "B"]))
+        A    0.333333
+        B    0.666667
+        Name: proportion, dtype: float64
+        >>> P(pd.Series(["A", "B", "B"]), weights=pd.Series([2, 1, 1]))
+        A    0.5
+        B    0.5
+        dtype: float64
 
     Arguments:
         x (:class:`pandas.core.series.Series`): A series of data.
@@ -19,12 +30,15 @@ def P(x, weights=None, subset=None):
         :class:`pandas.core.series.Series`: A Series which index are x's unique elements
             and which values are their probability in x.
     """
-    if weights is not None:
-        return weights.groupby(x).sum() / weights.sum()
-    if subset is None:
-        return x.value_counts(normalize=True, sort=False)
-    else:
+
+    if (subset is not None) and (weights is not None):
+        return weights[subset].groupby(x[subset]).sum() / weights[subset].sum()
+    elif subset is not None:
         return x[subset].value_counts(normalize=True, sort=False)
+    elif weights is not None:
+        return weights.groupby(x).sum() / weights.sum()
+    else:
+        return x.value_counts(normalize=True, sort=False)
 
 
 def cond_P(A, B, subset=None):

--- a/src/qumin/entropy/__init__.py
+++ b/src/qumin/entropy/__init__.py
@@ -74,6 +74,6 @@ def cond_entropy_slow(df, subset=None):
     Uses token frequencies to weight the patterns.
     """
     def compute_group_ent(group):
-        return entropy(P(group.pattern, weights=group.w_pair)) * group.w_x.sum()
+        return entropy(P(group.pattern, weights=group.f_pair)) * group.f_pred.sum()
 
-    return 0 + df.groupby('applicable').apply(compute_group_ent).sum() / df.w_x.sum()
+    return 0 + df.groupby('applicable').apply(compute_group_ent).sum() / df.f_pred.sum()

--- a/src/qumin/entropy/__init__.py
+++ b/src/qumin/entropy/__init__.py
@@ -5,14 +5,19 @@ import numpy as np
 
 
 def P(x, weights=None, subset=None):
-    """Return the probability distribution of elements in a :class:`pandas.core.series.Series`.
+    """
+    Return the probability distribution of unique elements in a :class:`pandas.core.series.Series`.
+    The default is a Uniform probability distribution, where each token in `x` has the same
+    probability. If weights are provided, they will be used as the probability of the tokens.
 
     Arguments:
         x (:class:`pandas.core.series.Series`): A series of data.
+        weights (:class:`pandas.core.series.Series`): A series of weights.
         subset (Iterable): Only give the distribution for a subset of values.
 
     Returns:
-        :class:`pandas.core.series.Series`: A Series which index are x's elements and which values are their probability in x.
+        :class:`pandas.core.series.Series`: A Series which index are x's unique elements
+            and which values are their probability in x.
     """
     if weights is not None:
         return weights.groupby(x).sum() / weights.sum()

--- a/src/qumin/entropy/distribution.py
+++ b/src/qumin/entropy/distribution.py
@@ -187,7 +187,7 @@ class PatternDistribution(object):
                 H( \textrm{patterns}_{c1, c2} | \textrm{classes}_{c1, c2} )
 
         The probability distribution of the patterns, on which this entropy
-        is computed, is established eithor on the type or token frequency of
+        is computed, is established either on the type or token frequency of
         the patterns. The probability of the pattern (:math:`p_i`) is the sum
         of the frequencies of all pairs of forms :math:`(x, y)` that instanciate
         this pattern (:math:`S_i`):
@@ -204,10 +204,10 @@ class PatternDistribution(object):
             debug (bool): Whether to print a debug log. Defaults to False
             token_patterns (bool): Whether to use token frequencies to compute
                 pattern probabilities.
-            token_predictors (bool): Whether to use token frequencies to compute
-                pattern probabilities.
+            token_predictors (bool): Whether to use token frequencies to weight
+                the predictors.
             legacy (bool): Whether to use faster legacy computations.
-                This necessarily disables tokens.
+                This necessarily disables token frequencies.
         """
         log.info("Computing c1 → c2 entropies")
         log.debug("Logging one predictor probabilities")
@@ -436,7 +436,8 @@ class PatternDistribution(object):
 
         Arguments:
             n (int): number of predictors.
-            df (pandas.DataFrame): a DataFrame containing patterns and applicable patterns for pairs of forms.
+            df (pandas.DataFrame): a DataFrame containing patterns
+                and applicable patterns for pairs of forms.
             paradigms (pandas.DataFrame): a DataFrame of paradigms.
             pat_order (dict): a dictionary to normalize cell names.
             zeros (dict): a dictionary of pairs that lead to an entropy of zero.
@@ -541,7 +542,8 @@ class PatternDistribution(object):
 
         Arguments:
             n (int): number of predictors.
-            df (pandas.DataFrame): a DataFrame containing patterns and applicable patterns for pairs of forms.
+            df (pandas.DataFrame): a DataFrame containing patterns
+                and applicable patterns for pairs of forms.
             paradigms (pandas.DataFrame): a DataFrame of paradigms.
             pat_order (dict): a dictionary to normalize cell names.
             n (int): number of predictors

--- a/src/qumin/entropy/distribution.py
+++ b/src/qumin/entropy/distribution.py
@@ -285,6 +285,7 @@ class PatternDistribution(object):
             """ Produces a nice summary for a subclass"""
             ex = subgroup.iloc[0, :]
             freq = subgroup.f_pair.sum() / total if total is not None else subgroup.shape[0]
+            freq = 0 if pd.isna(freq) else freq
 
             return pd.Series([
                               f"{ex.lexeme}: {ex.form_x} → {ex.form_y}",
@@ -323,6 +324,7 @@ class PatternDistribution(object):
 
             # Get the slow computation results
             table['proba'] = table.subclass_size / table.subclass_size.sum()
+            table.fillna(0, inplace=True)
             ent = 0 + entropy(table.proba)
             summary.append([members.f_pred.sum(), ent])
 


### PR DESCRIPTION
As discussed elsewhere, I am splitting up PR #57 into several smaller PRs.

This one is complementary to #58 and introduces token frequencies in two places :

1. The probability of the patterns (that is, the probability distribution on which the entropy is computed)
2. The entropy metrics (weighting of the predictors)

I needed to write slightly differently the entropy computation. I made computations with token frequencies the default and I introduced a `legacy` keyword to force the former, faster computation (which is not compatible with token frequencies so far).

There is some doc in the one_pred_entropy method and I can send you a more detailed document which explains the probabilistic setting.