### PR TITLE
fix divide by zero in entropy

### DIFF
--- a/src/qumin/entropy/__init__.py
+++ b/src/qumin/entropy/__init__.py
@@ -57,9 +57,13 @@ def cond_entropy(A, B, **kwargs):
 def entropy(A):
     """Calculate the entropy for a series of probabilities.
 
+    Since some probabilities may be null, we keep only positive values.
+    This does not affect the result of the computation.
+
     Arguments:
         A (:class:`pandas.core.series.Series`): A series of data.
 
     Return:
         H(A)"""
-    return -(A * np.log2(A)).sum()
+    pos = A > 0
+    return -(A[pos] * np.log2(A[pos])).sum()


### PR DESCRIPTION
This is a proper fix for the repeated divide by zero warning when computing entropies.

Possible solutions:

- Temporarily disable the warning with np.errstate: works, but I prefer not disabling warnings.
- Use np.log2(A, where A>0, out=np.zeros_like(A)) : this works if A is an array, but it doesn't work with pandas. In our case, we have series.
- Exclude zero values from the computation (they do not affect the result) -> **Implemented solution.** 