### PR TITLE
Read a subset of cell pairs from pattern computations

### DIFF
--- a/sphinx/changelog.rst
+++ b/sphinx/changelog.rst
@@ -6,7 +6,7 @@ Qumin follows the `semver <https://semver.org/>`_ principles for versioning. Thi
 dev version (forthcoming)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Add a `pos` keyword to filter paradigms on POS.
+- Add a `pos` keyword to filter paradigms on POS and improve the behaviour of `cells`.
 - Prevent Matplotlib font manager from spamming the log in debug mode.
 - Adds a Frequency class able to handle multiple paralex sources for frequencies.
 - Switch patterns management to long format everywhere

--- a/src/qumin/calc_paradigm_entropy.py
+++ b/src/qumin/calc_paradigm_entropy.py
@@ -51,6 +51,7 @@ def H_command(cfg, md):
     patterns = ParadigmPatterns()
     patterns.from_file(patterns_folder_path,
                        paradigms.data,
+                       cells=cells,
                        defective=defective,
                        overabundant=False,
                        force=cfg.force,

--- a/src/qumin/representations/patterns.py
+++ b/src/qumin/representations/patterns.py
@@ -997,8 +997,8 @@ class ParadigmPatterns(dict):
         # Raise error if cell was not found.
         if cells is not None and (set(cells) != set(self.cells)):
             raise ValueError("Couldn't find patterns for the following cells: "
-                             f"{", ".join(list(set(cells) - set(self.cells)))}. "
-                             "Check your patterns.""")
+                             f"{', '.join(list(set(cells) - set(self.cells)))}. "
+                             "Check your patterns.")
 
     def from_csv(self, path, pair, patterns_map, collection,
                  paradigms, defective=True, overabundant=True,


### PR DESCRIPTION
Again a small improvement for debug purposes.

You computed your patterns over a set of 50 cells. Now you want to test your entropy measures on a set of 3 cells. You don't need to recompute your patterns for three cells, just pass `cells="[cell1, cell2, cell3]"` and add the path to your patterns. Qumin will only read the required pairs of cells.

(notice that we still need to rewrite how Qumin discovers the patterns, because we don't want it to be done from the file names: this will be for another PR)