### PR TITLE
Feature rewrite metadata

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,22 +24,22 @@ For more detail, you can refer to Sacha's dissertation (in French, `Beniamine 20
 
 
 Citing
-============
+======
 
 If you use Qumin in your research, please cite Sacha's dissertation (`Beniamine 2018 <https://tel.archives-ouvertes.fr/tel-01840448>`_), as well as the relevant paper for the specific actions used (see below). To appear in the publications list, send Sacha an email with the reference of your publication at s.<last name>@surrey.ac.uk
 
 Quick Start
-============
+===========
 
 Install
---------
+-------
 
 Install the Qumin package using pip: ::
 
     pip install qumin
 
 Data
------
+----
 
 Qumin works from full paradigm data in phonemic transcription.
 
@@ -47,13 +47,14 @@ The package expects `Paralex datasets <http://www.paralex-standard.org>`_, conta
 
 Computation results are provided as a `Frictionless DataPackage <https://datapackage.org/>`_. In addition to the files provided in the output directory, Qumin also writes a `metadata.json` file, which contains:
 
-- A description of each file in the output directory
+- A description of each file in the output directory.
 - Timestamps for the beginning and the end of the run.
-- The arguments passed to the script
+- The command-line arguments passed to the script.
+- The description of the Paralex package used for the computations.
 
 
 Scripts
---------
+-------
 
 .. note::
     We now rely on `hydra <https://hydra.cc/>`_ to manage CLI interface and configurations. Hydra will create a folder ``outputs/<yyyy-mm-dd>/<hh-mm-ss>/`` containing all results. A subfolder ``outputs/<yyyy-mm-dd>/<hh-mm-ss>/.hydra/`` contains details of the configuration as it was when the script was run. Hydra permits a lot more configuration. For example, any of the following scripts can accept a verbose argument of the form ``hydra.verbose=Qumin``, and the output directory can be customized with ``hydra.run.dir="./path/to/output/dir"``.
@@ -63,7 +64,7 @@ Scripts
     /$ qumin --help
 
 Patterns
-^^^^^^^^^
+^^^^^^^^
 
 Alternation patterns serve as a basis for all the other scripts. An early version of the patterns algorithm is described in `Beniamine (2017) <https://halshs.archives-ouvertes.fr/hal-01615899>`_. An updated description figures in `Beniamine, Bonami and  Luís (2021) <https://doi.org/10.5565/rev/isogloss.109>`_.
 
@@ -83,7 +84,7 @@ For inflection class lattices, both can be kept: ::
     /$ qumin pats.defective=True pats.overabundant=True data=<dataset.package.json>
 
 Microclasses
-^^^^^^^^^^^^^
+^^^^^^^^^^^^
 
 To visualize the microclasses and their similarities, one can compute a **microclass heatmap**::
 
@@ -109,7 +110,7 @@ A few more parameters can be changed: ::
 
 
 Paradigm entropy
-^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^
 
 An early version of this software was used in `Bonami and Beniamine 2016 <http://www.llf.cnrs.fr/fr/node/4789>`_, and a more recent one in `Beniamine, Bonami and Luís (2021) <https://doi.org/10.5565/rev/isogloss.109>`_
 
@@ -184,7 +185,7 @@ The config file contains the following keys, which can be set through the comman
 
 
 Macroclass inference
-^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^
 
 Our work on automatical inference of macroclasses was published in `Beniamine, Bonami and Sagot (2018) <http://jlm.ipipan.waw.pl/index.php/JLM/article/view/184>`_".
 
@@ -196,7 +197,7 @@ By default, this will start by computing patterns. To work with pre-computed pat
 
 
 Lattices
-^^^^^^^^^
+^^^^^^^^
 
 By default, this will start by computing patterns. To work with pre-computed patterns, pass the path to the pattern computation metadata with ``patterns=<path/to/metadata.json>``.
 

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Qumin works from full paradigm data in phonemic transcription.
 
 The package expects `Paralex datasets <http://www.paralex-standard.org>`_, containing at least a `forms` and a `sounds` table. Note that the sounds files may sometimes require edition, as Qumin imposes more constraints on sound definitions than paralex does.
 
-Computation results are provided as a `Frictionless DataPackage <https://datapackage.org/>`_. In addition to the output files, Qumin also writes in the output directory a `metadata.json` file, which contains:
+Computation results are provided as a `Frictionless DataPackage <https://datapackage.org/>`_. In addition to the output files, Qumin also writes in the output directory a ``metadata.json`` file, which contains:
 
 - A description of each file in the output directory.
 - Timestamps for the beginning and the end of the run.
@@ -53,7 +53,7 @@ Computation results are provided as a `Frictionless DataPackage <https://datapac
 - The description of the Paralex package used for the computations.
 
 .. warning::
-    Patterns computed with Qumin 2.0 are not importable in Qumin 3.0 due to a breaking change in the output format. When importing patterns, Qumin 3.0 now expects a path to a ``metadata.json`` file.
+    Patterns and entropies computed with Qumin 2.0 are not importable in Qumin 3.0 due to a breaking change in the output format. When importing computation results, Qumin 3.0 now expects a path to the ``metadata.json`` file, which contains relative paths to the output files.
 
 Scripts
 -------
@@ -146,7 +146,7 @@ The config file contains the following keys, which can be set through the comman
         - 1
       features: null      # Feature column in the Lexeme table.
                           # Features will be considered known in conditional probabilities: P(X~Y|X,f1,f2...)
-      importFile: null    # Import entropy file with n-1 predictors (allows for acceleration on nPreds entropy computation).
+      importResults: null    # Import entropy file with n-1 predictors (allows for acceleration on nPreds entropy computation).
       merged: False       # Whether identical columns are merged in the input.
 
 Visualizing results
@@ -170,7 +170,7 @@ To facilitate a quick general glance at the results, we output an entropy heatma
 
 It is also possible to draw an entropy heatmap without running entropy computations: ::
 
-    /$ qumin action=ent_heatmap entropy.importFile=<entropies.csv>
+    /$ qumin action=ent_heatmap entropy.importResults=<metadata.json>
 
 The config file contains the following keys, which can be set through the command line: ::
 

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,12 @@ Qumin works from full paradigm data in phonemic transcription.
 
 The package expects `Paralex datasets <http://www.paralex-standard.org>`_, containing at least a `forms` and a `sounds` table. Note that the sounds files may sometimes require edition, as Qumin imposes more constraints on sound definitions than paralex does.
 
+Computation results are provided as a `Frictionless DataPackage <https://datapackage.org/>`_. In addition to the files provided in the output directory, Qumin also writes a `metadata.json` file, which contains:
+
+- A description of each file in the output directory
+- Timestamps for the beginning and the end of the run.
+- The arguments passed to the script
+
 
 Scripts
 --------
@@ -83,13 +89,13 @@ To visualize the microclasses and their similarities, one can compute a **microc
 
     /$ qumin action=heatmap data=<dataset.package.json>
 
-This will compute patterns, then the heatmap. To pass pre-computed patterns, pass the file path: ::
+This will compute patterns, then the heatmap. To pass pre-computed patterns, pass the patterns computation metadata path: ::
 
-    /$ qumin action=heatmap patterns=<path/to/patterns.csv> data=<dataset.package.json>
+    /$ qumin action=heatmap patterns=<path/to/metadata.json> data=<dataset.package.json>
 
 It is also possible to pass class labels to facilitate comparisons with another classification: ::
 
-    /$ qumin.heatmap label=inflection_class patterns=<path/to/patterns.csv> data=<dataset.package.json>
+    /$ qumin.heatmap label=inflection_class patterns=<path/to/metadata.json> data=<dataset.package.json>
 
 The label key is the name of the column in the Paralex `lexemes` table to use as labels.
 
@@ -107,7 +113,7 @@ Paradigm entropy
 
 An early version of this software was used in `Bonami and Beniamine 2016 <http://www.llf.cnrs.fr/fr/node/4789>`_, and a more recent one in `Beniamine, Bonami and Luís (2021) <https://doi.org/10.5565/rev/isogloss.109>`_
 
-By default, this will start by computing patterns. To work with pre-computed patterns, pass their path with ``patterns=<path/to/patterns.csv>``.
+By default, this will start by computing patterns. To work with pre-computed patterns, pass the path to the pattern computation metadata with ``patterns=<path/to/metadata.json>``.
 
 **Computing entropies from one cell** ::
 
@@ -123,8 +129,8 @@ By default, this will start by computing patterns. To work with pre-computed pat
 
 Predicting with known lexeme-wise features (such as gender or inflection class) is also possible. This feature was used in `Pellegrini (2023) <https://doi.org/10.1007/978-3-031-24844-3>`_. To use features, pass the name of any column(s) from the ``lexemes`` table: ::
 
-    /$ qumin.H  feature=inflection_class patterns=<patterns.csv> data=<dataset.package.json>
-    /$ qumin.H  feature="[inflection_class,gender]" patterns=<patterns.csv> data=<dataset.package.json>
+    /$ qumin.H  feature=inflection_class patterns=<metadata.json> data=<dataset.package.json>
+    /$ qumin.H  feature="[inflection_class,gender]" patterns=<metadata.json> data=<dataset.package.json>
 
 
 The config file contains the following keys, which can be set through the command line: ::
@@ -182,7 +188,7 @@ Macroclass inference
 
 Our work on automatical inference of macroclasses was published in `Beniamine, Bonami and Sagot (2018) <http://jlm.ipipan.waw.pl/index.php/JLM/article/view/184>`_".
 
-By default, this will start by computing patterns. To work with pre-computed patterns, pass their path with ``patterns=<path/to/patterns.csv>``.
+By default, this will start by computing patterns. To work with pre-computed patterns, pass the path to the pattern computation metadata with ``patterns=<path/to/metadata.json>``.
 
 **Inferring macroclasses** ::
 
@@ -192,7 +198,7 @@ By default, this will start by computing patterns. To work with pre-computed pat
 Lattices
 ^^^^^^^^^
 
-By default, this will start by computing patterns. To work with pre-computed patterns, pass their path with ``patterns=<path/to/patterns.csv>``.
+By default, this will start by computing patterns. To work with pre-computed patterns, pass the path to the pattern computation metadata with ``patterns=<path/to/metadata.json>``.
 
 This software was used in `Beniamine (2021) <https://langsci-press.org/catalog/book/262>`_".
 

--- a/README.rst
+++ b/README.rst
@@ -45,13 +45,15 @@ Qumin works from full paradigm data in phonemic transcription.
 
 The package expects `Paralex datasets <http://www.paralex-standard.org>`_, containing at least a `forms` and a `sounds` table. Note that the sounds files may sometimes require edition, as Qumin imposes more constraints on sound definitions than paralex does.
 
-Computation results are provided as a `Frictionless DataPackage <https://datapackage.org/>`_. In addition to the files provided in the output directory, Qumin also writes a `metadata.json` file, which contains:
+Computation results are provided as a `Frictionless DataPackage <https://datapackage.org/>`_. In addition to the output files, Qumin also writes in the output directory a `metadata.json` file, which contains:
 
 - A description of each file in the output directory.
 - Timestamps for the beginning and the end of the run.
 - The command-line arguments passed to the script.
 - The description of the Paralex package used for the computations.
 
+.. warning::
+    Patterns computed with Qumin 2.0 are not importable in Qumin 3.0 due to a breaking change in the output format. When importing patterns, Qumin 3.0 now expects a path to a ``metadata.json`` file.
 
 Scripts
 -------
@@ -82,6 +84,8 @@ For paradigm entropy, it is possible to explicitly keep defective lexemes: ::
 For inflection class lattices, both can be kept: ::
 
     /$ qumin pats.defective=True pats.overabundant=True data=<dataset.package.json>
+
+:doc:`patterns` provides more details on patterns.
 
 Microclasses
 ^^^^^^^^^^^^

--- a/sphinx/changelog.rst
+++ b/sphinx/changelog.rst
@@ -6,7 +6,7 @@ Qumin follows the `semver <https://semver.org/>`_ principles for versioning. Thi
 Version 3.0
 ~~~~~~~~~~~
 
-- Add a `pos` keyword to filter paradigms on POS and improve the behaviour of `cells`.
+- Add a ``pos`` keyword to filter paradigms on POS and improve the behaviour of ``cells``.
 - Usage of frequencies:
     - Read frequencies from as much sources as possible in the Paralex package (Frequencies class).
     - Weight cells based on the predictor-target pair frequency.
@@ -14,22 +14,22 @@ Version 3.0
 - Switch patterns management to long format everywhere
 - Change the format of human readable patterns to a more readable markdown export
 - Implement parallelisation for finding patterns and finding applicable patterns. See `cpus` config option.
-- Change management of Metadata class. Outputs from Qumin are now shipped as a `Frictionless DataPackage <https://datapackage.org/>`_.
+- Change management of imports/exports. Outputs from Qumin are now shipped as a `Frictionless DataPackage <https://datapackage.org/>`_. To import them, a path to the computation ``metadata.json`` must be provided.
 - Change management of sampling:
-    - `most_freq=False` replaced by `force_random=True`.
+    - ``most_freq=False`` replaced by ``force_random=True``.
     - Addition of a seed option to determinise sampling.  By default, sample by frequency.
-    - Change `sample` for `sample_lexemes` and add `sample_cells` with the same behaviour for cells.
+    - Change ``sample`` for ``sample_lexemes`` and add ``sample_cells`` with the same behaviour for cells.
 - Removal:
     - Support for sound table "Seg." column.
     - Bipartite entropy computations
-    - All alternation algorithms except `phon` and `edits` (former `patternsPhonsim` and `patternsLevenshtein`).
+    - All alternation algorithms except ``phon`` and ``edits`` (former ``patternsPhonsim`` and ``patternsLevenshtein``).
     
 Version 2.0
 ~~~~~~~~~~~
 
 * Support for the Paralex standard.
 * Automatic generation of heatmaps for entropy computations.
-* Add a `cells` keyword to filter paradigms on cells.
+* Add a ``cells`` keyword to filter paradigms on cells.
 * Several bugfixes
 * Removal:
     * Support for wide paradigms.

--- a/sphinx/changelog.rst
+++ b/sphinx/changelog.rst
@@ -13,6 +13,7 @@ Version 3.0
 - Prevent Matplotlib font manager from spamming the log in debug mode.
 - Switch patterns management to long format everywhere
 - Implement parallelisation for finding patterns and finding applicable patterns. See `cpus` config option.
+- Change management of Metadata class. Outputs from Qumin are now shipped as a `Frictionless DataPackage <https://datapackage.org/>`_.
 - Change management of sampling:
     - `most_freq=False` replaced by `force_random=True`.
     - Addition of a seed option to determinise sampling.  By default, sample by frequency.

--- a/sphinx/patterns.rst
+++ b/sphinx/patterns.rst
@@ -1,8 +1,7 @@
 Alternation patterns
-=================================
+====================
 
-.. note::
-    This script generates a human readable file `human_readable_<kind>.csv` which is only intended for manual inspection, as well as a file `<kind>.csv`, eg `phon.csv`, which is intended to be passed to further Qumin scripts.
+This script generates alternation patterns. They can be consumed by further Qumin scripts by passing the path to the ``metadata.json`` file produced by a computation. It also writes human readable patterns in the ``patterns/human_readable`` folder, which are intended for manual inspection.
 
 The patterns can be further configured, modifying the following keys: ::
 
@@ -15,7 +14,7 @@ The patterns can be further configured, modifying the following keys: ::
     force_random: False       # Whether to force random sampling.
     seed: 1                   # Random seed for reproducible random effects.
     pats:
-      kind: phon   # Options are (see docs): phon, edits
+      kind: phon              # Options are (see docs): phon, edits
       defective: False        # Whether to keep defective entries
       overabundant: False     # Whether to keep overabundant entries
       gap_proportion: .4      # Proportion of the median score used to set the gap score
@@ -28,7 +27,7 @@ values for these keys can be given through the command line, eg::
 
 
 Patterns kinds
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 Qumin can compute various kinds of patterns that can be used for entropy calculations. They have alternations and generalized contexts:
 

--- a/src/qumin/calc_paradigm_entropy.py
+++ b/src/qumin/calc_paradigm_entropy.py
@@ -81,8 +81,8 @@ def H_command(cfg, md):
         log.info("Mean H(c1 -> c2) = %s ", mean)
 
     if preds:
-        if cfg.entropy.importFile:
-            distrib.import_file(cfg.entropy.importFile)
+        if cfg.entropy.importResults:
+            distrib.import_file(cfg.entropy.importResults)
         for n in preds:
             if verbose:
                 distrib.n_preds_entropy(n, paradigms, debug=verbose)
@@ -94,5 +94,3 @@ def H_command(cfg, md):
     log.info("Writing to: {}".format(ent_file))
     distrib.export_file(ent_file, tokens=cfg.entropy.token_freq.cells)
     md.register_file('entropies.csv', description="Entropy computation results")
-
-    return ent_file

--- a/src/qumin/calc_paradigm_entropy.py
+++ b/src/qumin/calc_paradigm_entropy.py
@@ -13,6 +13,7 @@ from .entropy.distribution import PatternDistribution
 from .representations import segments, create_features
 from .representations.patterns import ParadigmPatterns
 from .representations.paradigms import Paradigms
+from .utils import Metadata
 
 log = logging.getLogger()
 
@@ -20,7 +21,7 @@ log = logging.getLogger()
 def H_command(cfg, md):
     r"""Compute entropies of flexional paradigms' distributions."""
     verbose = HydraConfig.get().verbose is not False
-    patterns_folder_path = cfg.patterns
+    patterns_run_md = Metadata(path=cfg.patterns) if cfg.patterns else md
     sounds_file_name = md.get_table_path("sounds")
     defective = cfg.pats.defective
 
@@ -33,7 +34,7 @@ def H_command(cfg, md):
     segments.Inventory.initialize(sounds_file_name)
 
     # Inflectional paradigms: rows are forms, with lexeme and cell..
-    paradigms = Paradigms(md.dataset,
+    paradigms = Paradigms(md.paralex,
                           defective=defective,
                           overabundant=False,
                           merge_cols=cfg.entropy.merged,
@@ -47,7 +48,7 @@ def H_command(cfg, md):
                                           seed=cfg.seed),
                           )
     patterns = ParadigmPatterns()
-    patterns.from_file(patterns_folder_path,
+    patterns.from_file(patterns_run_md,
                        paradigms.data,
                        cells=cfg.cells,
                        defective=defective,
@@ -69,7 +70,7 @@ def H_command(cfg, md):
     patterns.info()
 
     distrib = PatternDistribution(patterns,
-                                  md.dataset,
+                                  md.paralex,
                                   features=features)
 
     if onePred:
@@ -89,11 +90,9 @@ def H_command(cfg, md):
             mean = distrib.get_mean(n=n, tokens=cfg.entropy.tokens.cells)
             log.info(f"Mean H(c1, ..., c{n} -> c) = {mean}")
 
-    ent_file = md.register_file('entropies.csv',
-                                {'computation': 'entropies',
-                                 'content': 'results'})
-
+    ent_file = md.get_path('entropies.csv')
     log.info("Writing to: {}".format(ent_file))
     distrib.export_file(ent_file, tokens=cfg.entropy.tokens.cells)
+    md.register_file('entropies.csv', description="Entropy computation results")
 
     return ent_file

--- a/src/qumin/cli.py
+++ b/src/qumin/cli.py
@@ -29,7 +29,7 @@ def qumin_command(cfg):
         pat_command(cfg, md)
 
     if cfg.action == "H":
-        cfg.entropy.importFile = H_command(cfg, md)
+        H_command(cfg, md)
     elif cfg.action == "macroclasses":
         macroclasses_command(cfg, md)
     elif cfg.action == "lattice":

--- a/src/qumin/cli.py
+++ b/src/qumin/cli.py
@@ -16,7 +16,7 @@ log = logging.getLogger()
 @hydra.main(version_base=None, config_path="config", config_name="qumin")
 def qumin_command(cfg):
     log.info(cfg)
-    md = Metadata(cfg, __file__)
+    md = Metadata(cfg=cfg)
 
     if (cfg.patterns is None or cfg.action == "patterns") and \
             cfg.action != 'ent_heatmap':
@@ -26,8 +26,7 @@ def qumin_command(cfg):
         for_m = cfg.action == "macroclasses"
         assert not_overab or not (for_H or for_m), "For this calculation, overabundant must be False"
         assert not_defect or not for_m, "For this calculation, defective must be False"
-        patterns_file = pat_command(cfg, md)
-        cfg.patterns = patterns_file
+        pat_command(cfg, md)
 
     if cfg.action == "H":
         cfg.entropy.importFile = H_command(cfg, md)

--- a/src/qumin/clustering/algorithms.py
+++ b/src/qumin/clustering/algorithms.py
@@ -18,9 +18,7 @@ def choose(iterable):
 
 
 def log_classes(classes, md, suffix):
-    filename = md.register_file(suffix + ".txt",
-                                {"computation": "macroclasses",
-                                 "content": "log"})
+    filename = md.get_path(suffix + ".txt")
     log.info("Found %s %s", len(classes), suffix)
     log.info("Printing log to %s", filename)
     with open(filename, "w", encoding="utf-8") as flow:
@@ -28,6 +26,8 @@ def log_classes(classes, md, suffix):
             flow.write("\n\n{} ({}) \n\t".format(m,
                                                  len(classes[m]))
                        + ", ".join(classes[m]))
+
+    md.register_file(suffix + ".txt", description="Log of the macroclass computation")
 
 
 def hierarchical_clustering(patterns, paradigms, Clusters, **kwargs):

--- a/src/qumin/config/qumin.yaml
+++ b/src/qumin/config/qumin.yaml
@@ -27,65 +27,65 @@ hydra:
 
 disable_existing_loggers: false
 
-action: patterns      # Action, one of: patterns, H, lattice, eval, macroclasses, heatmap, ent_heatmap
-data: null            # path to paralex.package.json paradigms, segments
-cells: null           # List of cells to use (subset)
-pos: null             # List of parts of speech to use (subset)
-patterns: null        # path to pattern computation metadata. If null, will compute patterns.
+action: patterns      # (str) Action, one of: patterns, H, lattice, eval, macroclasses, heatmap, ent_heatmap
+data: null            # (path) Path to paralex.package.json paradigms, segments
+cells: null           # (list) Cells to use (subset)
+pos: null             # (list) Parts of speech to use (subset)
+patterns: null        # (path) Path to pattern computation metadata. If null, will compute patterns.
 sample_lexemes: null  # (int) A number of lexemes to sample, for debug purposes.
 sample_cells: null    # (int) A number of lexemes to sample, for debug purposes.
                       # Samples by frequency if possible, otherwise randomly.
-force_random: False   # Whether to force random sampling.
-seed: 1               # Random seed for reproducible random effects.
-force: False          # Whether to overpass RAM usage security (2GB)
-cpus: null            # Number of cpus to use for big computations
+force_random: False   # (bool) Whether to force random sampling.
+seed: 1               # (int) Random seed for reproducible random effects.
+force: False          # (bool) Whether to overpass RAM usage security (2GB)
+cpus: null            # (int) Number of cpus to use for big computations
                       # (defaults to the number of available cpus - 2).
 
 lattice:
-  shorten: False      # Drop redundant columns altogether.
-                      #  Useful for big contexts, but loses information.
+  shorten: False      # (bool) Drop redundant columns altogether.
+                      # Useful for big contexts, but loses information.
                       # The lattice shape and stats will be the same.
                       # Avoid using with --html
-  aoc: False          # Only attribute and object concepts
-  html: False         # Export to html
-  ctxt: False         # Export as a context
-  stat: False         # Output stats about the lattice
-  pdf: True           # Export as pdf
-  png: False          # Export as png
+  aoc: False          # (bool) Only attribute and object concepts
+  html: False         # (bool) Export to html
+  ctxt: False         # (bool) Export as a context
+  stat: False         # (bool) Output stats about the lattice
+  pdf: True           # (bool) Export as pdf
+  png: False          # (bool) Export as png
 
 heatmap:
-  label: null              # lexeme column to use as label (for microclass heatmap, eg. inflection_class)
-  cmap: null               # colormap name
-  exhaustive_labels: False # by default, seaborn shows only some labels on
+  label: null              # (str) Lexeme column to use as label (for microclass heatmap, eg. inflection_class)
+  cmap: null               # (str) Colormap name
+  exhaustive_labels: False # (bool) by default, seaborn shows only some labels on
                            # the heatmap for readability.
                            # This forces seaborn to print all labels.
-  dense: False             # Use initials instead of full labels (only for entropy heatmap)
-  annotate: False          # Display values on the heatmap. (only for entropy heatmap)
-  order: False             # Priority list for sorting features (for entropy heatmap)
+  dense: False             # (bool) Use initials instead of full labels (only for entropy heatmap)
+  annotate: False          # (bool) Display values on the heatmap. (only for entropy heatmap)
+  order: False             # (list) Priority list for sorting features (for entropy heatmap)
                            # ex: [number, case]). If no features-values file available,
                            # it should contain an ordered list of the cells to display.
 
 entropy:
-  heatmap: True       # Whether to draw a heatmap.
-  n:                  # Compute entropy for prediction from with n predictors.
+  heatmap: True       # (bool )Whether to draw a heatmap.
+  n:                  # (list) Compute entropy for prediction from with n predictors.
     - 1
-  features: null      # Feature column in the Lexeme table.
+  features: null      # (str) Feature column in the Lexeme table.
                       # Features will be considered known in conditional probabilities: P(X~Y|X,f1,f2...)
-  importFile: null    # Import entropy file
+  importResults: null # (path) Import previous entropy computation results.
                       # with any file, use to compute entropy heatmap
                       # with n-1 predictors, allows for acceleration on nPreds entropy computation.
-  merged: False       # Whether identical columns are merged in the input.
+  merged: False       # (bool) Whether identical columns are merged in the input.
   token_freq:         # Whether to use token frequencies for weighting...
-    cells: False      # Cell frequencies
+    cells: False      # (bool) Cell frequencies
 
 eval:
-  iter: 10            # How many 90/10 train/test folds to do.
-  workers: 1          # Number of threads for multithreading
+  iter: 10            # (int) How many 90/10 train/test folds to do.
+  workers: 1          # (int) Number of threads for multithreading
 
 pats:
-  kind: phon              # Options are (see docs): phon, edits
-  defective: False        # Whether to keep defective entries
-  overabundant: False     # Whether to keep overabundant entries
-  gap_proportion: .4      # Proportion of the median score used to set the gap score
-  optim_mem: False        # Attempt to use a little bit less memory
-  merged: False           # Whether to merge identical columns in the data
+  kind: phon              # (str) Options are (see docs): phon, edits
+  defective: False        # (bool) Whether to keep defective entries
+  overabundant: False     # (bool) Whether to keep overabundant entries
+  gap_proportion: .4      # (float) Proportion of the median score used to set the gap score
+  optim_mem: False        # (bool) Attempt to use a little bit less memory
+  merged: False           # (bool) Whether to merge identical columns in the data

--- a/src/qumin/config/qumin.yaml
+++ b/src/qumin/config/qumin.yaml
@@ -31,7 +31,7 @@ action: patterns      # Action, one of: patterns, H, lattice, eval, macroclasses
 data: null            # path to paralex.package.json paradigms, segments
 cells: null           # List of cells to use (subset)
 pos: null             # List of parts of speech to use (subset)
-patterns: null        # path to pre-computed patterns. If null, will compute patterns.
+patterns: null        # path to pattern computation metadata. If null, will compute patterns.
 sample_lexemes: null  # (int) A number of lexemes to sample, for debug purposes.
 sample_cells: null    # (int) A number of lexemes to sample, for debug purposes.
                       # Samples by frequency if possible, otherwise randomly.
@@ -75,7 +75,7 @@ entropy:
                       # with any file, use to compute entropy heatmap
                       # with n-1 predictors, allows for acceleration on nPreds entropy computation.
   merged: False       # Whether identical columns are merged in the input.
-  token_freq:             # Whether to use token frequencies for weighting...
+  tokens:             # Whether to use token frequencies for weighting...
     cells: False      # Cell frequencies
 
 eval:

--- a/src/qumin/config/qumin.yaml
+++ b/src/qumin/config/qumin.yaml
@@ -75,7 +75,7 @@ entropy:
                       # with any file, use to compute entropy heatmap
                       # with n-1 predictors, allows for acceleration on nPreds entropy computation.
   merged: False       # Whether identical columns are merged in the input.
-  token_freq:             # Whether to use token frequencies for weighting...
+  token_freq:         # Whether to use token frequencies for weighting...
     cells: False      # Cell frequencies
 
 eval:

--- a/src/qumin/entropy/distribution.py
+++ b/src/qumin/entropy/distribution.py
@@ -8,12 +8,13 @@ Encloses distribution of patterns on paradigms.
 import logging
 from collections import Counter, defaultdict
 from functools import reduce
-from itertools import combinations, permutations
+from itertools import combinations
 from operator import mul
 import pandas as pd
 
 from ..representations.frequencies import Frequencies
 from . import cond_entropy, entropy
+from ..utils import Metadata
 
 log = logging.getLogger("Qumin")
 
@@ -257,7 +258,8 @@ class PatternDistribution(object):
                 return tuple(preds.split("&"))
             return preds
 
-        data = pd.read_csv(filename)
+        entropy_md = Metadata(path=filename)
+        data = pd.read_csv(entropy_md.get_resource_path('entropies'))
         data.loc[:, "predictor"] = data.loc[:, "predictor"].apply(split_if_multiple)
         self.add_measures(data)
 

--- a/src/qumin/entropy_heatmap.py
+++ b/src/qumin/entropy_heatmap.py
@@ -10,6 +10,7 @@ import pandas as pd
 import numpy as np
 import seaborn as sns
 import logging
+from .utils import Metadata
 
 # Prevent matplotlib font manager from spamming the log
 logging.getLogger('matplotlib.font_manager').disabled = True
@@ -199,12 +200,14 @@ def ent_heatmap_command(cfg, md):
     r"""Draw a heatmap of results similarities using seaborn.
     """
     log.info("Drawing a heatmap of the results...")
-    results = pd.read_csv(cfg.entropy.importFile, index_col=[0, 1])
+    entropy_md = Metadata(path=cfg.entropy.importResults) if cfg.entropy.importResults else md
+    results = pd.read_csv(entropy_md.get_resource_path('entropies'), index_col=[0, 1])
     try:
         features_file_name = md.get_table_path("features-values")
     except FrictionlessException:
         features_file_name = None
-        log.warning("Your package doesn't contain any features-values file. You should provide an ordered list of cells in command line.")
+        log.warning("Your package doesn't contain any features-values file. "
+                    "You should provide an ordered list of cells in command line.")
 
     feat_order = get_features_order(features_file_name, results, cfg.heatmap.order)
 

--- a/src/qumin/entropy_heatmap.py
+++ b/src/qumin/entropy_heatmap.py
@@ -190,7 +190,7 @@ def entropy_heatmap(results, md, cmap_name=False,
     cg.tight_layout()
 
     path = md.get_path("vis/entropyHeatmap.png")
-    log.info("Writing heatmap to: " + path)
+    log.info("Writing heatmap to: %s", path)
     cg.savefig(path, pad_inches=0.1)
     md.register_file("vis/entropyHeatmap.png", description="Entropy heatmap")
 

--- a/src/qumin/entropy_heatmap.py
+++ b/src/qumin/entropy_heatmap.py
@@ -185,17 +185,14 @@ def entropy_heatmap(results, md, cmap_name=False,
                               labelrotation=0)
 
     cg.set_axis_labels(x_var="Predicted", y_var="Predictor")
-    cg.fig.suptitle(f"Measured on the {md.dataset.name} dataset, version {md.dataset.version}")
+    cg.fig.suptitle(f"Measured on the {md.paralex.name} dataset, version {md.paralex.version}")
 
     cg.tight_layout()
 
-    name = md.register_file("entropyHeatmap.png",
-                            {"computation": "entropy_heatmap",
-                             "content": "figure"})
-
-    log.info("Writing heatmap to: " + name)
-
-    cg.savefig(name, pad_inches=0.1)
+    path = md.get_path("vis/entropyHeatmap.png")
+    log.info("Writing heatmap to: " + path)
+    cg.savefig(path, pad_inches=0.1)
+    md.register_file("vis/entropyHeatmap.png", description="Entropy heatmap")
 
 
 def ent_heatmap_command(cfg, md):

--- a/src/qumin/eval.py
+++ b/src/qumin/eval.py
@@ -179,7 +179,7 @@ def predict_two_directions(test_items, train_items, method, features=None):
 
 def prepare_data(cfg, md):
     """Create a multi-index paradigm table and if given a path, a features table."""
-    paradigms = Paradigms(md.dataset,
+    paradigms = Paradigms(md.paralex,
                           segcheck=True,
                           fillna=False,
                           merge_cols=cfg.pats.merged,
@@ -265,19 +265,13 @@ def eval_command(cfg, md):
     for info in general_infos:
         results[info] = general_infos[info]
 
-    computation = 'evalPatterns'
-    filename = md.register_file("eval_patterns.csv",
-                                {"computation": computation,
-                                 "content": "scores",
-                                 "source": paradigms_file_path})
+    filename = md.get_path('eval_patterns.csv')
     results.to_csv(filename)
+    md.register_file("eval_patterns.csv", description="Scores from patterns evaluation.")
 
     print_summary(results, general_infos)
     figs = to_heatmap(results, paradigms.columns.tolist())
     for name, fig in figs:
-        figname = md.register_file("eval_patterns_{}.png".format(name),
-                                   {"computation": computation,
-                                    "content": "heatmap",
-                                    "name": name,
-                                    "source": paradigms_file_path})
+        figname = md.get_path(f"eval_patterns_{name}.png")
         fig.savefig(figname, dpi=300, bbox_inches='tight', pad_inches=0.5)
+        md.register_file(f"eval_patterns_{name}.png", description="Heatmap of patterns evaluation.")

--- a/src/qumin/find_macroclasses.py
+++ b/src/qumin/find_macroclasses.py
@@ -39,7 +39,7 @@ def macroclasses_command(cfg, md):
     segments.Inventory.initialize(sounds_file_name)
 
     # Loading paradigms
-    paradigms = Paradigms(md.dataset, defective=defective, overabundant=overabundant,
+    paradigms = Paradigms(md.paralex, defective=defective, overabundant=overabundant,
                           merge_cols=cfg.entropy.merged,
                           segcheck=True,
                           cells=cfg.cells,
@@ -70,13 +70,10 @@ def macroclasses_command(cfg, md):
     DL = "Min :" + str(find_min_attribute(node, "DL"))
     experiment_id = " ".join(["Bottom-up DL clustering on ", DL])
 
-    computation = "macroclasses"
     # Saving png figure
     if MATPLOTLIB_LOADED:
         fig = plt.figure(figsize=(10, 20))
-        figname = md.register_file("figure.png",
-                                   {"computation": computation,
-                                    "content": "figure"})
+        figname = md.get_path("macroclass/figure.png")
         log.info("Drawing figure to: {}".format(figname))
         node.draw(horizontal=True,
                   square=True,
@@ -88,13 +85,13 @@ def macroclasses_command(cfg, md):
         fig.suptitle(experiment_id)
         fig.savefig(figname,
                     bbox_inches='tight', pad_inches=.5)
+        md.register_file("figure.png", description="Macroclass figure")
 
     # Saving text tree
-    treename = md.register_file("tree.txt",
-                                {"computation": computation,
-                                 "content": "tree"})
+    treename = md.get_path('macroclass/tree.txt')
     log.info("Printing tree to: {}".format(treename))
     flow = open(treename, "w", encoding="utf8")
     flow.write(node.tree_string())
     flow.write("\n" + experiment_id)
     flow.close()
+    md.register_file("macroclass/tree.txt", description="Macroclass tree")

--- a/src/qumin/find_patterns.py
+++ b/src/qumin/find_patterns.py
@@ -71,4 +71,4 @@ def pat_command(cfg, md):
             flow.write("\n\n{} ({}) \n\t".format(m, len(microclasses[m])) + ", ".join(microclasses[m]))
     md.register_file("microclasses.txt", description="Microclass computation")
 
-    return patterns.export(md, kind, optim_mem=cfg.pats.optim_mem)
+    patterns.export(md, kind, optim_mem=cfg.pats.optim_mem)

--- a/src/qumin/find_patterns.py
+++ b/src/qumin/find_patterns.py
@@ -29,7 +29,7 @@ def pat_command(cfg, md):
 
     merge_cols = True
 
-    paradigms = Paradigms(md.dataset,
+    paradigms = Paradigms(md.paralex,
                           defective=defective,
                           overabundant=overabundant,
                           merge_cols=merge_cols,
@@ -51,9 +51,6 @@ def pat_command(cfg, md):
                            gap_prop=cfg.pats.gap_proportion,
                            cpus=cfg.cpus or min(1, cpu_count() - 2))
 
-    # Concatenate the patterns as a dict. Cell names are turned into columns.
-    # patterns_df = pd.concat([df for df in patterns_dfs.values()]).reset_index(drop=True)
-
     if merge_cols and not cfg.pats.merged:  # Re-build duplicate columns
         paradigms.unmerge_columns()
         patterns.unmerge_columns(paradigms)
@@ -67,11 +64,11 @@ def pat_command(cfg, md):
                     "Please report this as a bug !")
 
     microclasses = find_microclasses(paradigms, patterns)
-    filename = md.register_file("microclasses.txt",
-                                {'computation': cfg.pats.kind, 'content': 'microclasses'})
+    filename = md.get_path("microclasses.txt")
     log.info("Found %s microclasses. Printing microclasses to %s", len(microclasses), filename)
     with open(filename, "w", encoding="utf-8") as flow:
         for m in sorted(microclasses, key=lambda m: len(microclasses[m])):
             flow.write("\n\n{} ({}) \n\t".format(m, len(microclasses[m])) + ", ".join(microclasses[m]))
+    md.register_file("microclasses.txt", description="Microclass computation")
 
     return patterns.export(md, kind, optim_mem=cfg.pats.optim_mem)

--- a/src/qumin/make_lattice.py
+++ b/src/qumin/make_lattice.py
@@ -7,8 +7,6 @@ Author: Sacha Beniamine.
 
 import logging
 
-import pandas as pd
-
 from .clustering import find_microclasses
 from .lattice.lattice import ICLattice
 from .representations import segments
@@ -30,7 +28,7 @@ def lattice_command(cfg, md):
     segments.Inventory.initialize(sounds_file_name)
 
     # Loading paradigms
-    paradigms = Paradigms(md.dataset,
+    paradigms = Paradigms(md.paralex,
                           defective=defective,
                           overabundant=overabundant,
                           merge_cols=cfg.entropy.merged,
@@ -64,33 +62,33 @@ def lattice_command(cfg, md):
                         keep_names=(not cfg.lattice.shorten))
 
     if cfg.lattice.stat:
-        statname = md.register_file('stats.txt', {"computation": cfg.action,
-                                                  "content": "stats"})
+        statname = md.get_path('lattice/stats.txt')
         with open(statname, "w", encoding="utf-8") as flow:
             flow.write(lattice.stats().to_frame().T.to_latex())
             log.info(lattice.stats().to_frame().T.to_latex())
+        md.register_file('lattice/stats.txt',  description="Lattice statistics")
 
     if cfg.lattice.png:
-        lattpng = md.register_file('lattice.png', {'computation': cfg.action,
-                                                   'content': 'figure'})
+        lattpng = md.get_path('lattice/lattice.png')
         lattice.draw(lattpng, figsize=(20, 10), title=None, point=True)
+        md.register_file('lattice/lattice.png',  description="Lattice PNG figure")
 
     if cfg.lattice.pdf:
-        lattpdf = md.register_file('lattice.pdf', {'computation': cfg.action,
-                                                   'content': 'figure'})
+        lattpdf = md.get_path('lattice/lattice.pdf')
         lattice.draw(lattpdf, figsize=(20, 10), title=None, point=True)
+        md.register_file('lattice/lattice.pdf',  description="Lattice PDF figure")
 
     if cfg.lattice.html:
-        latthtml = md.register_file('lattice.html', {'computation': cfg.action,
-                                                     'content': 'figure'})
+        latthtml = md.get_path('lattice/lattice.html')
         log.info("Exporting to html: " + latthtml)
         lattice.to_html(latthtml)
+        md.register_file('lattice/lattice.html',  description="Lattice HTML figure")
 
     if cfg.lattice.ctxt:
-        lattcxt = md.register_file('lattice.cxt', {'computation': cfg.action,
-                                                   'content': 'figure'})
+        lattcxt = md.get_path('lattice/lattice.cxt')
         log.info(" ".join(["Exporting context to file:", lattcxt]))
         lattice.context.tofile(lattcxt, frmat='cxt')
+        md.register_file('lattice/lattice.cxt',  description="Lattice CXT figure")
 
     log.info("Here is the first level of the hierarchy:")
     log.info("Root:")

--- a/src/qumin/microclass_heatmap.py
+++ b/src/qumin/microclass_heatmap.py
@@ -38,11 +38,11 @@ def microclass_heatmap(distances, md, labels=None, cmap_name="BuPu", exhaustive_
     else:
         sns.clustermap(distances, method="average", xticklabels=tick_value, yticklabels=tick_value,
                        linewidths=0, cmap=plt.get_cmap(cmap_name), rasterized=True)
-    name = md.register_file("microclassHeatmap.pdf",
-                            {"computation": "microclass_heatmap",
-                             "content": "figure"})
+
+    name = md.get_path('microclassHeatmap.pdf')
     log.info("Saving file to: " + name)
     plt.savefig(name, bbox_inches='tight', pad_inches=0, transparent=True)
+    md.register_file("microclassHeatmap.pdf", "Microclass heatmap")
 
 
 def distance_matrix(pat_table, microclasses, **kwargs):

--- a/src/qumin/microclass_heatmap.py
+++ b/src/qumin/microclass_heatmap.py
@@ -40,7 +40,7 @@ def microclass_heatmap(distances, md, labels=None, cmap_name="BuPu", exhaustive_
                        linewidths=0, cmap=plt.get_cmap(cmap_name), rasterized=True)
 
     name = md.get_path('microclassHeatmap.pdf')
-    log.info("Saving file to: " + name)
+    log.info("Saving file to: %s", name)
     plt.savefig(name, bbox_inches='tight', pad_inches=0, transparent=True)
     md.register_file("microclassHeatmap.pdf", "Microclass heatmap")
 

--- a/src/qumin/representations/patterns.py
+++ b/src/qumin/representations/patterns.py
@@ -910,16 +910,15 @@ class ParadigmPatterns(dict):
             return "ParadigmPatterns(empty)"
         return f"ParadigmPatterns({', '.join([a + '~' + b for a, b in dict.keys(self)])})"
 
-    def export(self, md, kind, optim_mem=False):
+    def export(self, md, *args, optim_mem=False):
         """
         Export dataframes to a folder for later use.
 
         Arguments:
-            kind (str): type of patterns (phon or edits).
             optim_mem (bool): Whether to not export human readable patterns too. Defaults to False.
         """
         # Save machine readable patterns
-        self.to_csv(md, kind)
+        self.to_csv(md, *args)
 
         # Save human readable patterns
         if optim_mem:
@@ -930,7 +929,7 @@ class ParadigmPatterns(dict):
             abs_path = md.get_path("patterns/human_readable/")
             log.info("Writing pretty patterns (for manual examination) to %s", abs_path)
             for pair in self.keys():
-                self.to_md(md, pair, rel_path, abs_path, kind)
+                self.to_md(md, pair, rel_path, abs_path, *args)
         return md.prefix
 
     def to_md(self, md, pair, rel_path, abs_path, kind):
@@ -938,10 +937,11 @@ class ParadigmPatterns(dict):
 
         Arguments:
             md (qumin.utils.Metadata): Metadata handler.
-            pair (Tuple[str, str]): cell names
-            folder (str):
-            kind (str):
-
+            pair (Tuple[str, str]): pair of cells for which a pattern file should
+                be exported.
+            rel_path (str): Relative path to the folder.
+            abs_path (str): Absolute path to the folder.
+            kind (str): type of patterns (phon or edits).
         """
         a, b = pair
         name = f"pat_{kind}_{a}-{b}"
@@ -969,8 +969,13 @@ class ParadigmPatterns(dict):
                                      f"with the '{kind}' algorithm.")
 
     def to_csv(self, md, kind, path="patterns/machine_readable/"):
-        """Export a Patterns DataFrame to csv."""
+        """Export a Patterns DataFrame to csv.
 
+        Arguments:
+            md (qumin.utils.Metadata): Metadata handler.
+            kind (str): type of patterns (phon or edits).
+            path (str): Relative path to the folder.
+        """
         # Path settings
         abs_path = md.get_path(path)
         log.info("Writing patterns (importable by other scripts) to %s", abs_path)
@@ -988,7 +993,7 @@ class ParadigmPatterns(dict):
         # One csv per pair of cells
         for (a, b) in self.keys():
             name = f"pat_{kind}_{kind}_{a}-{b}.csv"
-            export = self[(a,b)].copy()
+            export = self[(a, b)].copy()
 
             if not isinstance(export.pattern.iloc[0], str):
                 export.pattern = export.pattern.map(repr)

--- a/src/qumin/representations/patterns.py
+++ b/src/qumin/representations/patterns.py
@@ -925,16 +925,17 @@ class ParadigmPatterns(dict):
             patterns = self[pair]['pattern'].unique()
             pattern_list.update([repr(pat) for pat in patterns])
         pattern_map = {pat: n for n, pat in enumerate(pattern_list)}
-        filename = md.register_file("patterns_map.csv")
         s = pd.Series({n: pat for pat, n in pattern_map.items()}, name="patterns")
-        s.to_csv(filename)
+
+        s.to_csv(md.get_path("patterns/patterns_map.csv"))
+        md.register_file("patterns/patterns_map.csv")
 
         # Save regular patterns
-        folder = "patterns"
-        md.register_folder(folder, description="Compact machine readable patterns.")
-        log.info("Writing patterns (importable by other scripts) to %s", folder)
+        rel_path = "patterns/machine_readable/"
+        abs_path = md.get_path(rel_path)
+        log.info("Writing patterns (importable by other scripts) to %s", abs_path)
         for pair in self.keys():
-            self.to_csv(md, pair, folder, kind, pretty=optim_mem,
+            self.to_csv(md, pair, abs_path, rel_path, kind, "machine", pretty=optim_mem,
                         only_id=True, pattern_map=pattern_map)
 
         # Save human readable patterns
@@ -942,19 +943,23 @@ class ParadigmPatterns(dict):
             log.warning("Since you asked for args.optim_mem,"
                         "I will not export the human_readable file.")
         else:
-            folder = "patterns_human_readable"
-            md.register_folder(folder, description="Pretty patterns (for manual examination)")
-            log.info("Writing pretty patterns (for manual examination) to %s", folder)
+            rel_path = "patterns/human_readable/"
+            abs_path = md.get_path("patterns/human_readable/")
+            log.info("Writing pretty patterns (for manual examination) to %s", abs_path)
             for pair in self.keys():
-                self.to_csv(md, pair, folder, kind,
+                self.to_csv(md, pair, abs_path, rel_path, kind, "human",
                             pretty=True)
         return md.prefix
 
-    def to_csv(self, md, pair, folder, kind,
+    def to_csv(self, md, pair, abs_path, rel_path, algorithm, kind,
                pretty=False, only_id=False, pattern_map=None):
+
         """Export a Patterns DataFrame to csv."""
         a, b = pair
-        filename = md.register_file(f"{kind}_{a}-{b}.csv", folder=folder)
+        name = f"pat_{kind}_{algorithm}_{a}-{b}.csv"
+        rel_path = rel_path + name
+        abs_path = abs_path + "/" + name
+
         export_fun = str if pretty else repr
         export = self[pair].copy()
         export.pattern = export.pattern.map(export_fun)
@@ -965,41 +970,48 @@ class ParadigmPatterns(dict):
 
             # Replace patterns by ids
             export.pattern = export.pattern.map(pattern_map)
-        export.drop(["lexeme"], axis=1).to_csv(filename, sep=",", index=False)
+        export.drop(["lexeme"], axis=1).to_csv(abs_path, sep=",", index=False)
+        md.register_file(rel_path,
+                         custom=dict(cells=pair,
+                                     kind=kind + "_readable",
+                                     algorithm=algorithm),
+                         description=f"Patterns for {kind}s between cells '{a}' and '{b}', "
+                                     f"with the '{algorithm}' algorithm.")
 
-    def from_file(self, folder, *args, force=False, cells=None, **kwargs):
+    def from_file(self, patterns_md, *args, force=False, cells=None, **kwargs):
         """Read pattern data from a previous export.
 
         Arguments:
-            folder (str): path to the folder
+            patterns_md (Metadata): metadata handler from a previous run.
             cells (List[str]): a list of cell names to read.
-
-
         """
         collection = defaultdict(lambda: defaultdict(str))
-        folder = Path(folder)
 
         # Read patterns map
-        patterns_map = pd.read_csv(folder / 'patterns_map.csv', index_col=0).patterns
+        patterns_map = pd.read_csv(patterns_md.get_resource_path('patterns_map'),
+                                   index_col=0).patterns
+
+        # Get available patterns and their path
+        pattern_files = {}
+        for r in patterns_md.package.resources:
+            if 'cells' in r.custom and 'kind' in r.custom and r.custom['kind'] == "machine_readable":
+                pattern_files[tuple(sorted(r.custom['cells']))] = patterns_md.get_resource_path(r.name)
 
         # Parse patterns for each pair of cells
-        first = True
         log.info('Reading patterns...')
-        for path in tqdm((folder / "patterns").iterdir()):
-            reg = re.compile(r"[^_]+_(.+)-(.+)\.csv")
-            pair = tuple(reg.match(path.name).groups())
-            if cells is None or (set(pair) <= set(cells)):
-                self.from_csv(path, pair, patterns_map, collection, *args, **kwargs)
-                if first:
-                    n_files = len(list(folder.iterdir()))
-                    memory_check(list(self.values())[0], n_files, force=force)
-                    first = False
+        cell_pairs = [tuple(sorted(p)) for p in combinations(cells, 2)] \
+            if cells else pattern_files.keys()
 
-        # Raise error if cell was not found.
-        if cells is not None and (set(cells) != set(self.cells)):
-            raise ValueError("Couldn't find patterns for the following cells: "
-                             f"{', '.join(list(set(cells) - set(self.cells)))}. "
-                             "Check your patterns.")
+        first = True
+        for pair in tqdm(cell_pairs):
+            if pair not in pattern_files.keys():
+                raise ValueError("Couldn't find patterns for the following cell: "
+                                 f"{pair[0]}~{pair[1]}. Check your patterns.")
+            self.from_csv(pattern_files[pair], pair, patterns_map, collection,
+                          *args, **kwargs)
+            if first:
+                memory_check(list(self.values())[0], len(cell_pairs), force=force)
+                first = False
 
     def from_csv(self, path, pair, patterns_map, collection,
                  paradigms, defective=True, overabundant=True,
@@ -1008,12 +1020,13 @@ class ParadigmPatterns(dict):
         Read a patterns dataframe for a specific pair of cells
 
         Arguments:
-            paradigms (pandas.DataFrame): a paradigms dataframe, with form id's as index.
+            paradigms (pandas.DataFrame): a paradigms table, with form id's as index.
             defective (bool): whether to consider defective lexemes.
             overabundant (bool): whether to consider overabundance.
             collection (defaultdict): a defaultdict to avoid recomputing
                 patterns from strings.
             pair (tuple) a tuple of cells to read.
+            patterns_map (pandas.DataFrame): a DataFrame of patterns and pattern ids.
         """
 
         def read_pattern(string):

--- a/src/qumin/utils/__init__.py
+++ b/src/qumin/utils/__init__.py
@@ -54,7 +54,7 @@ class Metadata():
         if path is None:
             self.start = datetime.datetime.now()
             self.paralex = Package(cfg.data)
-            self.package.name = f"qumin_results_{self.start.strftime("%Hh%M_%Y%m%d")}"
+            self.package.name = self.start.strftime("qumin_results_%Hh%M_%Y%m%d")
             self.package.title = "Qumin Computation Results"
             self.package.homepage = "https://qumin.readthedocs.io/"
             self.package.description = "This package contains the output of a Qumin run. " \

--- a/src/qumin/utils/__init__.py
+++ b/src/qumin/utils/__init__.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # !/usr/bin/python3
-import json
 import logging
-import os
-import time
+import datetime
+from omegaconf import OmegaConf
 from pathlib import Path
 
 import hydra
-from frictionless import Package
+from frictionless import Package, Resource
 
 from .. import __version__
 
@@ -15,129 +14,100 @@ log = logging.getLogger()
 
 
 class Metadata():
-    """Metadata manager for Qumin scripts. Basic usage :
+    """Metadata manager for Qumin scripts. Wrapper around the Frictionless Package class.
+    Basic usage :
 
         1. Register Metadata manager;
-        2. Before writing any important file, register it with a short name;
-        3. Save all metadata in a secure place
+        2. Get an absolute path to the metadata folder;
+        3. Write to that path;
+        4. After writing a file, register it and set metadata (description, custom dict);
+        3. Export the JSON descriptor.
 
     Examples:
         .. code-block:: python
 
             md = Metadata(args, __file__)
-            filename = md.register_file(name, suffix)
-            # Now, you can open an IO stream and write to ``filename``.
+            name = 'path/myfile.txt'
+            filename = md.get_path(name)
+            # Open an IO stream and write to ``filename``.
+            md.register_file(name, description="My nice file", custom={"property": "value"})
             md.save_metadata(path)
 
     Arguments:
         cfg (:class:`pandas:pandas.DataFrame`):
             arguments passed to the script
-        filename (str): name of the main script, passing __file__ is fine.
+        path (str): name of the main script, passing __file__ is fine.
 
     Attributes:
-        now (str)
-        day (str)
-        version (str) : svn/git version or '' if unknown
-        prefix (str) : normalized prefix for the output files
-        arguments (dict): all arguments passed to the python script
-        output (dict) : all output files produced by the script.
-        dataset (tuple): a (directory path, Package) tuple representing a dataset.
+        start (datetime) : timestamp at the beginning of the run.
+        prefix (Path) : normalized prefix for the output files
+        cfg (OmegaConf): all arguments passed to the python script
+        paralex (frictionless.Package): a frictionless Package representing a dataset.
     """
 
-    def __init__(self, cfg, filename):
-        # Basic information
-        self.now = time.strftime("%Hh%M")
-        self.day = time.strftime("%Y%m%d")
-        self.version = get_version()
-        self.script = filename
-        self.working_dir = os.getcwd()
+    def __init__(self, path=None, cfg=None, **kwargs):
+        self.package = Package(path) if path else Package()
+        self.cfg = cfg
+        self.prefix = Path(self.package.basepath if path else
+                           hydra.core.hydra_config.HydraConfig.get().runtime.output_dir)
 
-        # Check directory
-        self.prefix = hydra.core.hydra_config.HydraConfig.get().runtime.output_dir + "/"
-
-        # Make it robust to multiple
-        if "data" in cfg:
-            data = cfg.data
-            self.dataset = Package(data)
-
-        # Additional CLI arguments
-        self.arguments = dict(cfg)
-        self.output = []
+        if path is None:
+            self.start = datetime.datetime.now()
+            self.paralex = Package(cfg.data)
+            self.package.name = f"qumin_results_{self.start.strftime("%Hh%M_%Y%m%d")}"
+            self.package.title = "Qumin Computation Results"
+            self.package.homepage = "https://qumin.readthedocs.io/"
+            self.package.description = "This package contains the output of a Qumin run. " \
+                                       "It can be imported by other Qumin scripts."
+            self.package.created = datetime.datetime.now().isoformat()
+            self.package.custom['qumin_version'] = __version__
+            if cfg:
+                self.package.custom['omega_conf'] = OmegaConf.to_container(cfg)
+            self.package.custom['paralex_dataset'] = self.paralex.to_dict()
 
     def get_table_path(self, table_name):
-        dataset = self.dataset
+        """ Return the path to a dataset table """
+        dataset = self.paralex
         basepath = Path(dataset.basepath or "./")
         return basepath / dataset.get_resource(table_name).path
 
+    def get_resource_path(self, resource):
+        """ Return the full path to a resource """
+        return self.prefix / self.package.get_resource(resource).path
+
     def save_metadata(self):
         """ Save the metadata as a JSON file."""
+        end = datetime.datetime.now()
+        self.package.custom['duration'] = {"start": str(self.start),
+                                           "end": str(end),
+                                           "delta": str(end - self.start)
+                                           }
+        self.package._basepath = str(self.prefix)
+        self.package.infer()
+        self.package.to_json(self.prefix / 'metadata.json')
 
-        def default_serializer(x):
-            if type(x) is Package:
-                return x.to_dict()
-            return str(x)
-
-        path = self.prefix + "metadata.json"
-        log.info("Writing metadata to %s", path)
-
-        with open(path, 'w', encoding='utf-8') as f:
-            json.dump(self.__dict__, f, ensure_ascii=False, indent=4, default=default_serializer)
-
-    def register_file(self, suffix, properties=None, folder=None):
-        """ Register a file to save. Returns a normalized name.
-
-        Arguments:
-            suffix (str): the suffix to append to the normalized prefix
-            properties (dict): optional set of properties to keep along
-            folder (str): name of a registered subdirectory where the file should be saved.
-
-        Returns:
-            (str): the full registered path"""
-
-        # Always check if the folder still exists.
-        if folder:
-            filename = Path(self.prefix) / folder / suffix
-            folder_mds = [entity for entity in self.output if entity.get('folder') == folder]
-            if len(folder_mds) == 0:
-                raise ValueError('This folder should first be registered')
-            else:
-                parent = folder_mds[0]['files']
+    def get_path(self, rel_path):
+        """ Return an absolute path to a file and create parent directories. """
+        path = Path(self.prefix) / rel_path
+        if rel_path[-1] != "/":
+            path.parent.mkdir(parents=True, exist_ok=True)
         else:
-            filename = Path(self.prefix) / suffix
-            parent = self.output
+            path.mkdir(parents=True, exist_ok=True)
+        return str(path)
 
-        parent.append({'filename': str(filename),
-                       'properties': properties})
-        return str(filename)
-
-    def register_folder(self, name, description=None):
-        """ Register a folder of data. Returns a normalized name.
+    def register_file(self, rel_path, custom=None, **kwargs):
+        """ Add a file as a frictionless resource.
 
         Arguments:
-            name (str): the name of the folder
-            description (str): a description of the content of the folder
-
-        Returns:
-            (str): the full registered path"""
-
-        # Always check if the folder still exists.
-        foldername = Path(self.prefix) / name
-        foldername.mkdir(parents=True, exist_ok=True)
-        self.output.append({'folder': name,
-                            'description': description,
-                            'files': []})
-        return str(foldername)
-
-
-def get_version():
-    """Return an ID for the current git or svn revision.
-
-    If the directory isn't under git or svn, the function returns an empty str.
-
-    Returns:
-        (str): svn/git version or ''.
-     """
-    return __version__
+            rel_path (str): the relative path to the file.
+            custom (dict): Custom properties to save.
+            **kwargs (dict): Optional keyword arguments passed to Resource,
+                e.g. `description`.
+        """
+        res = Resource(path=rel_path, **kwargs)
+        if custom is not None:
+            res.custom = custom
+        self.package.add_resource(res)
 
 
 def memory_check(df, factor, max_gb=2, force=False):

--- a/src/qumin/utils/__init__.py
+++ b/src/qumin/utils/__init__.py
@@ -87,25 +87,33 @@ class Metadata():
         self.package.to_json(self.prefix / 'metadata.json')
 
     def get_path(self, rel_path):
-        """ Return an absolute path to a file and create parent directories. """
+        """ Return an absolute path to a file and create parent directories.
+
+        Arguments:
+            rel_path (str): relative path to the file or folder.
+
+        Returns:
+            pathlib.Path: absolute path to the file or folder.
+        """
         path = Path(self.prefix) / rel_path
         if rel_path[-1] != "/":
             path.parent.mkdir(parents=True, exist_ok=True)
         else:
             path.mkdir(parents=True, exist_ok=True)
-        return str(path)
+        return path
 
     def register_file(self, rel_path, name=None, custom=None, **kwargs):
         """ Add a file as a frictionless resource.
 
         Arguments:
-            rel_path (str): the relative path to the file.
+            rel_path (str or pathlib.Path): the relative path to the file.
             name (str): name of the resource. By default, this will be the name
                 of the file without the extension.
             custom (dict): Custom properties to save.
             **kwargs (dict): Optional keyword arguments passed to Resource,
                 e.g. `description`.
         """
+        rel_path = str(rel_path)
         if isinstance(name, str):
             kwargs['name'] = name
         res = Resource(path=rel_path, **kwargs)


### PR DESCRIPTION
In this PR I completely rewrote the interface to manage metadata. The first one was a bit idiosyncratic, hard to update, etc. Closes #56 

Metadata is now a wrapper around frictionless.Package. It creates the Package, contains a few utilities (as adding our custom metadata to the package: run duration, qumin version, paralex dataset, etc + easy access to absolute paths) and is even able to import metadata from a previous run.

For instance, to reuse patterns from a previous run, you only need to provide the path to the  `metadata.json` file.

Drawback:
- No compatibility with runs from previous versions of Qumin

Benefits:
- It will be easy to change the folder structure, add new outputs, since the metadata does not reflect the folder structure.
- We benefit from the power of `frictionless.Package.infer()` which improves our metadata description.
- Shorter code, no need to reimplement basic features.